### PR TITLE
Add ESP-IDF example + outrun packaging fix for registry consumers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,16 @@ jobs:
         run: pip install uv platformio
       - name: Build PlatformIO m5stick-demo
         run: ./tools/run-tests.py build
+
+  build-espidf:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fetch Esp32Lua (not on ESP component registry)
+        run: ./examples/espidf-basic/tools/fetch-deps.sh
+      - name: Build espidf-basic example
+        uses: espressif/esp-idf-ci-action@v1
+        with:
+          esp_idf_version: v5.5.3
+          target: esp32
+          path: examples/espidf-basic

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ __pycache__/
 
 # Git worktrees (created by superpowers' using-git-worktrees skill)
 .worktrees/
+
+# clangd LSP index (per-project)
+.cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
     SRCS "src/OutrunSandbox.cpp" "src/OutrunDevice.cpp"
     INCLUDE_DIRS "src"
-    REQUIRES espressif__arduino-esp32 courier ArduinoJson Esp32Lua
+    REQUIRES espressif__arduino-esp32 inanimate__courier bblanchon__arduinojson Esp32Lua
 )

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,19 +2,41 @@
 
 ## v0.3.0-dev (d27cda1)
 
+### Breaking changes (ESP-IDF consumers only)
+
+**Outrun's `CMakeLists.txt` `REQUIRES` line now uses namespaced component
+names: `inanimate__courier` and `bblanchon__arduinojson` instead of bare
+`courier` and `ArduinoJson`.** This matches the names exposed by the ESP
+component registry, so consumers using registry-resolved deps work out of
+the box. Downstream IDF projects that vendor courier/ArduinoJson under
+their bare names (e.g. `vendor/courier/`, `arduino-deps/ArduinoJson/`)
+must rename them to the namespaced form, or vendor under both names, or
+switch to registry deps. PlatformIO consumers are unaffected — PIO uses
+`library.json`, not `CMakeLists.txt`.
+
+### New features
+
+- `examples/espidf-basic/`: minimal ESP-IDF example demonstrating Outrun
+  integration in a real-consumer style. Uses registry pins for
+  `espressif/arduino-esp32`, `inanimate/courier` (≥0.3.2), and
+  `bblanchon/arduinojson`; a small `tools/fetch-deps.sh` script handles
+  Esp32Lua (the only dep not on the ESP Component Registry, pinned by
+  commit SHA against the upstream Arduino lib).
+- Outrun's `idf_component.yml` now declares its dependencies on the
+  registry (`espressif/arduino-esp32`, `inanimate/courier`,
+  `bblanchon/arduinojson`), so IDF consumers no longer have to
+  re-declare them. `Esp32Lua` remains consumer-supplied (not on the
+  registry) — see the example's fetch script for the canonical pattern.
+
 ### Internal
 
 - Added `tools/run-tests.py` (uv inline-script) with `static-analysis`,
   `unit`, `build`, and `all` subcommands. Local entry point and CI driver.
 - Added `test/unit/` with a native PlatformIO env and a smoke assertion.
   Slot for future unit tests; no existing source is currently covered.
-- Added `.github/workflows/ci.yml` with three jobs: static analysis
-  (cppcheck), unit tests (PIO native), and PlatformIO build of
-  `m5stick-demo`. A fourth job for ESP-IDF builds is planned but deferred
-  pending an upstream `inanimate/courier` packaging fix (courier's CMake
-  REQUIRES line names `ezTime`, `ArduinoJson`, `WiFiManager` by bare names
-  but its `idf_component.yml` doesn't declare those deps, so consumers
-  can't `idf.py reconfigure` against the published registry version).
+- Added `.github/workflows/ci.yml` with four jobs: static analysis
+  (cppcheck), unit tests (PIO native), PlatformIO build of `m5stick-demo`,
+  and ESP-IDF build of `examples/espidf-basic` against IDF v5.5.3.
 - Patched `examples/m5stick-demo/device/platformio.ini` to use the in-tree
   Outrun source (`symlink://../../..`) and HTTPS for courier, so the demo
   builds in CI without SSH credentials. Added an explicit

--- a/examples/espidf-basic/CMakeLists.txt
+++ b/examples/espidf-basic/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.16.0)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(espidf-basic)

--- a/examples/espidf-basic/README.md
+++ b/examples/espidf-basic/README.md
@@ -1,0 +1,44 @@
+# espidf-basic
+
+Minimal ESP-IDF example showing how a consumer project integrates Outrun.
+Builds a no-op `BasicDevice` that registers a stub LED driver with the
+sandbox. Doesn't connect to any real network — `host` is `example.com`.
+
+## Prerequisites
+
+- ESP-IDF v5.5.x installed and sourced (`. $IDF_PATH/export.sh`).
+- `git` on PATH (for the dependency fetch step below).
+
+## Build
+
+From this directory:
+
+```bash
+./tools/fetch-deps.sh
+idf.py build
+```
+
+The fetch step clones [Esp32Lua](https://github.com/Fischer-Simon/Esp32Lua)
+and shims it as an IDF component under `components/Esp32Lua/`. It's pinned
+by commit SHA, idempotent (skips if already present), and the `components/`
+directory is gitignored.
+
+## Flash
+
+```bash
+idf.py -p /dev/cu.usbserial-XXXX flash monitor
+```
+
+Replace `/dev/cu.usbserial-XXXX` with your board's serial device.
+
+## Files
+
+- `main/main.cpp` — `app_main()` entry point and `BasicDevice` class.
+- `main/StubLEDDriver.{h,cpp}` — minimal `Outrun::Driver` implementation
+  that exposes a `led.set(r, g, b)` Lua function (no-op).
+- `main/idf_component.yml` — dependency manifest. Outrun comes from the
+  in-tree source via `path: ../../..`; the rest are registry pins.
+- `main/CMakeLists.txt` — IDF component registration.
+- `partitions.csv`, `sdkconfig.defaults` — minimal IDF project config.
+- `tools/fetch-deps.sh` — fetches Esp32Lua (the only dep that isn't on
+  the ESP Component Registry).

--- a/examples/espidf-basic/main/CMakeLists.txt
+++ b/examples/espidf-basic/main/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+    SRCS "main.cpp" "StubLEDDriver.cpp"
+    INCLUDE_DIRS "."
+    REQUIRES outrun espressif__arduino-esp32
+)

--- a/examples/espidf-basic/main/StubLEDDriver.cpp
+++ b/examples/espidf-basic/main/StubLEDDriver.cpp
@@ -1,0 +1,25 @@
+#include "StubLEDDriver.h"
+
+extern "C" {
+#include "lua/lua.h"
+#include "lua/lauxlib.h"
+}
+
+namespace {
+int l_set(lua_State* L) {
+    luaL_checkinteger(L, 1);
+    luaL_checkinteger(L, 2);
+    luaL_checkinteger(L, 3);
+    return 0;
+}
+
+const luaL_Reg led_funcs[] = {
+    {"set", l_set},
+    {nullptr, nullptr},
+};
+} // namespace
+
+void StubLEDDriver::installSandboxModule(lua_State* L) {
+    luaL_newlib(L, led_funcs);
+    lua_setglobal(L, "led");
+}

--- a/examples/espidf-basic/main/StubLEDDriver.h
+++ b/examples/espidf-basic/main/StubLEDDriver.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <OutrunDriver.h>
+
+// Minimal no-op driver. Exercises Sandbox::addDriver() without requiring
+// real hardware. Exposes an `led` table in Lua with one function:
+//   led.set(r, g, b)  -- accepts but ignores three integers
+class StubLEDDriver : public Outrun::Driver {
+public:
+    const char* name() const override { return "led"; }
+    void installSandboxModule(lua_State* L) override;
+};

--- a/examples/espidf-basic/main/idf_component.yml
+++ b/examples/espidf-basic/main/idf_component.yml
@@ -1,0 +1,25 @@
+dependencies:
+  idf:
+    version: ">=5.0.0"
+
+  # Outrun itself — built from the in-tree source so the example is also
+  # build verification for the library. Consumers copying this example
+  # should change this to a pinned registry version once outrun publishes.
+  outrun:
+    path: ../../..
+
+  # Registry deps — these are what real consumers depend on.
+  espressif/arduino-esp32:
+    version: "^3.0.0"
+
+  # Courier 0.3.2+ properly declares its transitive deps; earlier versions
+  # require consumers to provide ezTime/ArduinoJson/WiFiManager out of band.
+  inanimate/courier:
+    version: ">=0.3.2"
+
+  bblanchon/arduinojson:
+    version: "^7.0.0"
+
+  # Esp32Lua is not on the ESP component registry. It's fetched and shimmed
+  # into examples/espidf-basic/components/Esp32Lua/ by tools/fetch-deps.sh.
+  # Run that script BEFORE `idf.py build`.

--- a/examples/espidf-basic/main/main.cpp
+++ b/examples/espidf-basic/main/main.cpp
@@ -1,0 +1,43 @@
+// Minimal ESP-IDF example for Outrun. Demonstrates:
+//   - Subclassing Outrun::Device
+//   - Registering a driver with the sandbox
+//   - Running setup()/loop() from app_main() rather than autostarted Arduino
+//
+// This intentionally targets `example.com` — it won't actually connect.
+// Real consumers point `host` at their own Outrun server.
+
+#include <Arduino.h>
+#include <OutrunDevice.h>
+#include "StubLEDDriver.h"
+
+static StubLEDDriver led;
+
+static Outrun::DeviceConfig makeConfig() {
+    Outrun::DeviceConfig cfg;
+    cfg.deviceType = "espidf-basic";
+    cfg.host = "example.com";
+    return cfg;
+}
+
+class BasicDevice : public Outrun::Device {
+public:
+    BasicDevice() : Outrun::Device(makeConfig()) {}
+
+    void deviceSetup() override {
+        sandbox().addDriver(&led);
+        sandbox().initialize();
+    }
+
+    void deviceLoop() override {}
+};
+
+static BasicDevice device;
+
+extern "C" void app_main() {
+    initArduino();
+    device.setup();
+    while (true) {
+        device.loop();
+        vTaskDelay(pdMS_TO_TICKS(10));
+    }
+}

--- a/examples/espidf-basic/partitions.csv
+++ b/examples/espidf-basic/partitions.csv
@@ -1,0 +1,4 @@
+# Name,   Type, SubType, Offset,   Size, Flags
+nvs,      data, nvs,     0x9000,   0x6000,
+phy_init, data, phy,     0xf000,   0x1000,
+factory,  app,  factory, 0x10000,  3M,

--- a/examples/espidf-basic/sdkconfig.defaults
+++ b/examples/espidf-basic/sdkconfig.defaults
@@ -1,0 +1,27 @@
+# Target — esp32 by default; override with idf.py set-target esp32s3 etc.
+CONFIG_IDF_TARGET="esp32"
+
+# Flash (4MB default; matches partitions.csv above)
+CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y
+
+# Arduino integration: don't autostart; we drive setup()/loop() via app_main()
+CONFIG_AUTOSTART_ARDUINO=n
+
+# Arduino requires 1000Hz tick rate
+CONFIG_FREERTOS_HZ=1000
+
+# Main task stack — registration + JSON parsing needs more than the 3584 default
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=16384
+
+# Use our custom partition table
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
+CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"
+
+# mbedTLS: enable PSK ciphersuites. Required because arduino-esp32's
+# NetworkClientSecure/ssl_client.cpp is #if-gated on
+# MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED — without these, ssl_client.cpp
+# compiles to an empty object and NetworkClientSecure.cpp's link fails
+# with undefined references to start_ssl_client/ssl_init/etc.
+CONFIG_MBEDTLS_PSK_MODES=y
+CONFIG_MBEDTLS_KEY_EXCHANGE_PSK=y

--- a/examples/espidf-basic/tools/fetch-deps.sh
+++ b/examples/espidf-basic/tools/fetch-deps.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Fetches Esp32Lua and wraps it as an ESP-IDF component under
+# examples/espidf-basic/components/. Esp32Lua is not on the ESP Component
+# Registry, so a pure `idf.py build` can't resolve it.
+#
+# The upstream repo (https://github.com/Fischer-Simon/Esp32Lua) has no git
+# tags, only a main branch — so we pin by commit SHA via clone-then-checkout.
+# Bump the SHA below intentionally when picking up upstream changes.
+#
+# Re-runnable: skips clone if the target dir exists.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")/.." && pwd)"
+COMPONENTS="$DIR/components"
+mkdir -p "$COMPONENTS"
+
+ESP32LUA_URL="https://github.com/Fischer-Simon/Esp32Lua.git"
+ESP32LUA_SHA="53c7d504ee266532e625145dc141d76692063145"
+
+fetch_pinned() {
+    local name="$1" url="$2" sha="$3"
+    local target="$COMPONENTS/$name"
+    if [[ -d "$target" ]]; then
+        echo "  $name already present — skipping"
+        return
+    fi
+    echo "  fetching $name @ $sha"
+    git clone --quiet "$url" "$target"
+    git -C "$target" -c advice.detachedHead=false checkout --quiet "$sha"
+    rm -rf "$target/.git"
+}
+
+echo "Fetching Esp32Lua into $COMPONENTS"
+fetch_pinned Esp32Lua "$ESP32LUA_URL" "$ESP32LUA_SHA"
+
+# Shim CMakeLists for Esp32Lua — upstream ships an Arduino-style library,
+# not an IDF component. Glob the Lua C sources, exclude the standalone
+# interpreter and compiler entry points, register includes from src/.
+cat > "$COMPONENTS/Esp32Lua/CMakeLists.txt" <<'EOF'
+file(GLOB LUA_SRCS "src/lua/*.c")
+list(FILTER LUA_SRCS EXCLUDE REGEX "lua\\.c$|luac\\.c$")
+idf_component_register(SRCS ${LUA_SRCS} INCLUDE_DIRS "src")
+EOF
+
+echo "Done."

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,3 +1,17 @@
 version: "0.3.0-dev"
 description: "Sandbox with hardware IO and hot reload for ESP32 devices"
 url: "https://github.com/inanimate-tech/outrun"
+
+dependencies:
+  idf:
+    version: ">=5.0.0"
+  espressif/arduino-esp32:
+    version: "^3.0.0"
+  inanimate/courier:
+    version: ">=0.3.2"
+  bblanchon/arduinojson:
+    version: "^7.0.0"
+  # Esp32Lua is not on the ESP component registry. Consumers must provide it
+  # as a local component named `Esp32Lua` (e.g. via a fetch script that clones
+  # https://github.com/Fischer-Simon/Esp32Lua and writes a CMakeLists.txt).
+  # See examples/espidf-basic/tools/fetch-deps.sh for the canonical pattern.


### PR DESCRIPTION
## Summary
- New minimal ESP-IDF example at `examples/espidf-basic/` demonstrating Outrun integration the way a real consumer would. Resumes work that was deferred in #3 — courier 0.3.2 fixed the transitive-dep packaging issue that blocked us before.
- **Breaking for IDF consumers:** Outrun's `idf_component.yml` now declares its registry deps (arduino-esp32, courier ≥0.3.2, ArduinoJson), and `CMakeLists.txt` REQUIRES uses namespaced names (`inanimate__courier`, `bblanchon__arduinojson`). Same kind of fix courier 0.3.2 just shipped. PlatformIO consumers are unaffected (PIO uses `library.json`, not `CMakeLists.txt`). Downstream IDF projects vendoring courier/ArduinoJson under bare names need to rename or switch to registry deps.
- CI gains a fourth job (`build-espidf`) that fetches Esp32Lua and builds the example against IDF v5.5.3.
- Sdkconfig adds PSK ciphersuite enables so arduino-esp32's NetworkClientSecure can link (its `ssl_client.cpp` is `#if`-gated on PSK availability).
- Adds `.cache/` to `.gitignore` for clangd LSP indexes.

## Test plan
- [x] `./tools/run-tests.py all` passes locally (cppcheck, native unit, m5stick PIO build)
- [x] `idf.py build` in `examples/espidf-basic/` succeeds locally — binary 0x1439d0 bytes (58% free in 3MB partition)
- [ ] All four CI jobs pass on this PR (static-analysis, unit-tests, build-platformio, build-espidf)
- [ ] Skim `examples/espidf-basic/README.md` for clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)