### PR TITLE
Scope published tarballs to library files only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ __pycache__/
 # personal context, in-progress thinking, and absolute paths.
 docs/superpowers/
 examples/*/docs/superpowers/
+
+# Local pack output (pio pkg pack / compote component pack)
+dist/

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -18,3 +18,31 @@ dependencies:
   # as a local component named `Esp32Lua` (e.g. via a fetch script that clones
   # https://github.com/Fischer-Simon/Esp32Lua and writes a CMakeLists.txt).
   # See examples/espidf-basic/tools/fetch-deps.sh for the canonical pattern.
+files:
+  # compote does not read .gitignore — we must explicitly exclude build
+  # artifacts and dev-only files, or they end up in the published tarball.
+  exclude:
+    - "**/.pio/**/*"
+    - "**/node_modules/**/*"
+    - "**/managed_components/**/*"
+    - "**/build/**/*"
+    - "dist/**/*"
+    - "examples/**/*"
+    - "device-apps/**/*"
+    - ".claude/**/*"
+    - ".github/**/*"
+    - ".vscode/**/*"
+    - "docs/superpowers/**/*"
+    - "tools/**/*"
+    - "test/**/*"
+    - "**/.DS_Store"
+    - "**/package-lock.json"
+    - "**/sdkconfig"
+    - "**/sdkconfig.*"
+    - "**/dependencies.lock"
+    - "CLAUDE.md"
+    - "docs/publishing.md"
+    - "docs/changelog.md"
+    - "docs/start-building.md"
+    - "docs/migration-0.4-to-0.5.md"
+    - ".gitignore"

--- a/library.json
+++ b/library.json
@@ -20,5 +20,16 @@
     "inanimate/courier": "https://github.com/inanimate-tech/courier.git",
     "bblanchon/ArduinoJson": "^7.4.2",
     "fischer-simon/Esp32Lua": "^5.4.7"
+  },
+  "export": {
+    "include": [
+      "src/**/*",
+      "CMakeLists.txt",
+      "idf_component.yml",
+      "library.json",
+      "LICENSE",
+      "README.md",
+      "docs/api.md"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Add `export.include` whitelist to `library.json` (PlatformIO)
- Add `files.exclude` to `idf_component.yml` (ESP Component Registry — compote does not read `.gitignore`)

Without these, the published tarballs would contain the entire working tree (examples, `.claude/`, `CLAUDE.md`, `docs/superpowers/`, tools, tests).

After this change: **17 files** in the PIO tarball, **20 files** in the ESP tarball (was 6,777 / 20,227).

## Test plan

- [x] `pio pkg pack` produces a 17-file tarball: src/, manifests, README, LICENSE, CMakeLists.txt, docs/api.md
- [x] `compote component pack --name resident` produces a 20-file tarball (same set + dir entries)
- [ ] CI passes