### PR TITLE
feat(sandbox): display AP name during WiFi configuration

### DIFF
--- a/examples/m5stick-demo/device/lib/drivers/src/DisplayDriver.cpp
+++ b/examples/m5stick-demo/device/lib/drivers/src/DisplayDriver.cpp
@@ -26,8 +26,10 @@ void DisplayDriver::displayText(const char* text) {
   M5.Display.fillScreen(TFT_BLACK);
   M5.Display.setTextColor(TFT_WHITE);
   M5.Display.setTextSize(2);
+  M5.Display.setScrollRect(10, 60, M5.Display.width() - 10, M5.Display.height() - 60);
+  M5.Display.setTextScroll(true);
   M5.Display.setCursor(10, 60);
-  M5.Display.println(text);
+  M5.Display.print(text);
 }
 
 void DisplayDriver::onAppReset() {

--- a/examples/m5stick-demo/device/lib/drivers/src/DisplayDriver.cpp
+++ b/examples/m5stick-demo/device/lib/drivers/src/DisplayDriver.cpp
@@ -26,10 +26,11 @@ void DisplayDriver::displayText(const char* text) {
   M5.Display.fillScreen(TFT_BLACK);
   M5.Display.setTextColor(TFT_WHITE);
   M5.Display.setTextSize(2);
-  M5.Display.setScrollRect(10, 60, M5.Display.width() - 10, M5.Display.height() - 60);
+  M5.Display.setScrollRect(4, 60, M5.Display.width() - 8, M5.Display.height() - 60);
   M5.Display.setTextScroll(true);
-  M5.Display.setCursor(10, 60);
+  M5.Display.setCursor(4, 60);
   M5.Display.print(text);
+  M5.Display.setTextScroll(false);   // restore global default; drawn pixels unaffected
 }
 
 void DisplayDriver::onAppReset() {

--- a/src/ResidentSandbox.cpp
+++ b/src/ResidentSandbox.cpp
@@ -334,7 +334,7 @@ void Sandbox::onCourierConnectionChange(Courier::State state)
     case S::WifiConnecting:        showStatusText("WiFi..."); break;
     case S::WifiConfiguring: {
       // Build status text, appending AP name when available
-      String s = _apName.isEmpty() ? "Configure WiFi" : (String("Configure WiFi\n") + _apName);
+      String s = _apName.isEmpty() ? "Configure WiFi" : (String("Configure WiFi\n\n") + _apName);
       showStatusText(s.c_str());
       break;
     }

--- a/src/ResidentSandbox.cpp
+++ b/src/ResidentSandbox.cpp
@@ -252,8 +252,8 @@ void Sandbox::setup()
     String apName = String(getDeviceType());
     if (apName.length() > 0) apName[0] = toupper(apName[0]);
     String idSuffix = _deviceId.substring(0, 4);
-    _courier->setAPName(
-      (String("Resident ") + apName + " " + idSuffix).c_str());
+    _apName = String("Resident ") + apName + " " + idSuffix;
+    _courier->setAPName(_apName.c_str());
 
     Serial.printf("[resident] Device: %s (%s)\n",
                   getDeviceType(), _deviceId.c_str());
@@ -332,7 +332,12 @@ void Sandbox::onCourierConnectionChange(Courier::State state)
   // after, in addition (does not replace).
   switch (state) {
     case S::WifiConnecting:        showStatusText("WiFi..."); break;
-    case S::WifiConfiguring:       showStatusText("Configure WiFi"); break;
+    case S::WifiConfiguring: {
+      // Build status text, appending AP name when available
+      String s = _apName.isEmpty() ? "Configure WiFi" : (String("Configure WiFi\n") + _apName);
+      showStatusText(s.c_str());
+      break;
+    }
     case S::WifiConnected:         showStatusText("WiFi connected"); break;
     case S::TransportsConnecting:  showStatusText("Connecting..."); break;
     case S::Connected:             showStatusText("Connected"); break;

--- a/src/ResidentSandbox.h
+++ b/src/ResidentSandbox.h
@@ -95,6 +95,7 @@ public:
 
     // ── Identity / status accessors ──
     const String& getDeviceId() const { return _deviceId; }
+    const String& getAPName() const { return _apName; }
     const char* getDeviceType() const {
       return _config.deviceType ? _config.deviceType : "device";
     }
@@ -126,6 +127,7 @@ private:
     std::optional<Courier::Client> _courier;
     Courier::WebSocketTransport* _ws = nullptr;
     String _deviceId;
+    String _apName;
 
     // User-registered callbacks (single-slot, last registration wins).
     ConfigureNetworkCallback      _onConfigureNetwork;


### PR DESCRIPTION
Update the setup display at the wifi configure stage do display WAP name.
Additionally, in m5stick-demo example code, make displayText gracefully handle multi-line text input.