### PR TITLE
fix(sandbox): Lua allocator falls back to internal RAM on no-PSRAM boards

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.5.1-dev (7915694)
+
+### Fixes
+
+- **Lua allocator falls back to internal RAM on boards without PSRAM** (e.g. ESP32-S3FN8 / M5Dial). Previously every Lua allocation went to `MALLOC_CAP_SPIRAM`, which returns NULL when no PSRAM exists — the Lua runtime had no usable heap and every app failed with "not enough memory". The capability is now resolved once on first use: SPIRAM when present, internal 8-bit RAM otherwise. Boards with PSRAM are unaffected.
+
+---
+
 ## v0.5.0
 
 First public alpha.

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.5.0"
+version: "0.5.1-dev"
 description: "Sandbox with hardware IO and hot reload for ESP32 devices"
 url: "https://github.com/inanimate-tech/resident"
 

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "resident",
-  "version": "0.5.0",
+  "version": "0.5.1-dev",
   "description": "Sandbox with hardware IO and hot reload for ESP32 devices",
   "keywords": "esp32, sandbox, iot, hot-reload",
   "repository": {

--- a/src/ResidentSandbox.cpp
+++ b/src/ResidentSandbox.cpp
@@ -14,18 +14,23 @@ extern "C" {
 #ifdef ESP_PLATFORM
 #include "esp_heap_caps.h"
 
-// Custom Lua allocator that routes all allocations to PSRAM.
+// Custom Lua allocator. Prefers PSRAM, but transparently falls back to
+// internal RAM on boards without PSRAM (e.g. ESP32-S3FN8). The capability is
+// resolved once on first use from whether any SPIRAM is actually present.
 static void* psramLuaAlloc(void* ud, void* ptr, size_t osize, size_t nsize) {
   (void)ud;
   (void)osize;
+  static const uint32_t kLuaHeapCaps =
+      (heap_caps_get_total_size(MALLOC_CAP_SPIRAM) > 0) ? MALLOC_CAP_SPIRAM
+                                                        : MALLOC_CAP_8BIT;
   if (nsize == 0) {
     heap_caps_free(ptr);
     return NULL;
   }
   if (ptr == NULL) {
-    return heap_caps_malloc(nsize, MALLOC_CAP_SPIRAM);
+    return heap_caps_malloc(nsize, kLuaHeapCaps);
   }
-  return heap_caps_realloc(ptr, nsize, MALLOC_CAP_SPIRAM);
+  return heap_caps_realloc(ptr, nsize, kLuaHeapCaps);
 }
 #endif
 


### PR DESCRIPTION
## Summary

The sandbox's custom Lua allocator routed every allocation to `MALLOC_CAP_SPIRAM`. On boards without PSRAM (e.g. ESP32-S3FN8 / M5Dial) those allocations all return NULL, so the Lua runtime has no usable heap and every app fails with `not enough memory`.

The capability is now resolved once on first use — SPIRAM when any is present, internal 8-bit RAM otherwise. Boards with PSRAM keep their Lua heap there, exactly as before.

Version → 0.5.1-dev; changelog updated.

## Testing

- 20 native unit tests pass; cppcheck static analysis passes.
- Hardware-verified on M5Dial (no PSRAM): Lua apps compile and run; multi-mode clock/timer app runs at 10 FPS with no allocator failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)