### PR TITLE
feat(sandbox): suspendApp/resumeApp — pause a running app without unloading it

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -174,6 +174,9 @@ sandbox.sendAppEvent(name, dataJson);  // queue an app_event to the running app
 sandbox.setTimezone("Europe/London");  // IANA zone — performs UDP lookup on first use
 sandbox.hasTimezone();                 // true after a successful setTimezone call
 sandbox.isAppRunning();                // true when an app is compiled and active
+sandbox.suspendApp();                  // pause the running app's tick without unloading it
+sandbox.resumeApp();                   // resume a suspended app
+sandbox.isAppSuspended();              // true between suspendApp() and resumeApp()
 sandbox.generationId();                // const String& — ID of the last loaded app/shader
 sandbox.setTelemetryCallback(cb);      // wire telemetry JSON to your transport
 ```
@@ -181,6 +184,8 @@ sandbox.setTelemetryCallback(cb);      // wire telemetry JSON to your transport
 `loadApp` stops any running app, calls `onAppReset()` on all extensions, generates a new `generationId`, and compiles the new app. An app must define at least one of `init`, `on_tick`, or `on_event` — compilation is rejected otherwise.
 
 `loadShader` requires `SandboxConfig::shaderTemplate` to be set; it converts the `ShaderFields` map to Lua source, then calls `loadApp`.
+
+`suspendApp` pauses the Lua tick (`on_tick` and event dispatch) without unloading the app — Courier and extension `update()` keep running. While suspended, drivers receive `onAppRunning(false)` so the status display is freed for direct text (e.g. a "Listening" overlay via `StatusDisplay::displayText()`); `resumeApp` reverses this with `onAppRunning(true)`. Both are no-ops when no app is loaded, and repeated calls don't re-notify. `isAppRunning()` stays `true` while suspended — suspension is a separate axis queried via `isAppSuspended()`. Events arriving while suspended are queued, not dropped (though a long suspend can overflow the 8-slot ring, losing the oldest), and `loadApp` always clears suspension.
 
 `setTimezone` is a no-op on `nullptr` or empty input. Success means ezTime resolved the zone (either from its own cache or via one UDP lookup to `timezoned.rop.nl`); failure logs and leaves `hasTimezone() == false`. Affects `ctx.localtime_h`, `ctx.localtime_m`, `time.hour()`, `time.minute()`, and `time.second()` in Lua.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.5.1-dev (7915694)
+## v0.5.1-dev (77afc9a)
 
 ### New features
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,15 @@
 
 ## v0.5.1-dev (7915694)
 
+### New features
+
+- `Resident::Sandbox::suspendApp()` / `resumeApp()` / `isAppSuspended()` — pause
+  and resume a running app's tick without unloading it. While suspended,
+  `loop()` skips the Lua `on_tick`/event dispatch (Courier and extension updates
+  keep running) and the status display is freed for direct text via
+  `StatusDisplay::displayText()`. The m5stick-voice example uses it to show
+  "Listening" over a running app during push-to-talk.
+
 ### Fixes
 
 - **Lua allocator falls back to internal RAM on boards without PSRAM** (e.g. ESP32-S3FN8 / M5Dial). Previously every Lua allocation went to `MALLOC_CAP_SPIRAM`, which returns NULL when no PSRAM exists — the Lua runtime had no usable heap and every app failed with "not enough memory". The capability is now resolved once on first use: SPIRAM when present, internal 8-bit RAM otherwise. Boards with PSRAM are unaffected.

--- a/examples/m5stick-demo/device/lib/drivers/src/DisplayDriver.cpp
+++ b/examples/m5stick-demo/device/lib/drivers/src/DisplayDriver.cpp
@@ -33,6 +33,10 @@ void DisplayDriver::displayText(const char* text) {
   M5.Display.setTextScroll(false);   // restore global default; drawn pixels unaffected
 }
 
+void DisplayDriver::repaint() {
+  if (_initialized) _canvas.pushSprite(0, 0);
+}
+
 void DisplayDriver::onAppReset() {
   if (_initialized) {
     _canvas.fillScreen(TFT_BLACK);

--- a/examples/m5stick-demo/device/lib/drivers/src/DisplayDriver.h
+++ b/examples/m5stick-demo/device/lib/drivers/src/DisplayDriver.h
@@ -41,6 +41,12 @@ public:
   // Call once after M5.begin() to create the sprite framebuffer
   void begin() override;
 
+  // Re-push the current off-screen sprite to the display without redrawing it.
+  // Restores the last app frame after a direct displayText() overlay (e.g. the
+  // m5stick-voice "Listening" prompt). Essential for apps that render only in
+  // init(); tick-driven apps would otherwise redraw on their next on_tick.
+  void repaint();
+
 protected:
   M5Canvas _canvas{&M5.Display};
 

--- a/examples/m5stick-voice/device/src/main.cpp
+++ b/examples/m5stick-voice/device/src/main.cpp
@@ -96,6 +96,13 @@ Resident::SandboxConfig makeConfig() {
 
 Resident::Sandbox sandbox{makeConfig()};
 
+// Idle prompt: the hold-to-talk hint with the deviceId on the line below, so
+// the id needed to pair/push is readable straight off the screen.
+static void showIdlePrompt() {
+    String msg = String("Hold button\nto talk\n") + sandbox.getDeviceId();
+    displayDriver.displayText(msg.c_str());
+}
+
 // Push-to-talk. A plain C function pointer — cannot capture, so it works
 // against the file-scope globals above. The same callback fires for both
 // edges: started=true once the hold passes the threshold, started=false on
@@ -107,12 +114,18 @@ static void onHold(bool started) {
         dbgFramesRec = dbgFramesSent = dbgSendFail = 0;
         dbgHoldStarts++;
         streaming = true;
+        if (sandbox.isAppRunning()) sandbox.suspendApp();
         displayDriver.displayText("Listening");
         Serial.printf("[voice] %lu HOLD start (#%lu) -> streaming\n",
                       millis(), dbgHoldStarts);
     } else {
         streaming = false;
-        displayDriver.displayText("Hold button\nto talk");
+        if (sandbox.isAppRunning()) {
+            sandbox.resumeApp();
+            displayDriver.repaint();  // restore the app's last frame immediately
+        } else {
+            showIdlePrompt();
+        }
         Serial.printf("[voice] %lu HOLD end -> stopped "
                       "(rec=%lu sent=%lu fail=%lu)\n",
                       millis(), dbgFramesRec, dbgFramesSent, dbgSendFail);
@@ -154,7 +167,7 @@ void setup() {
         Serial.printf("[voice] device id %s — viewer: https://%s/devices/%s/\n",
                       sandbox.getDeviceId().c_str(), SERVER_HOST,
                       sandbox.getDeviceId().c_str());
-        if (!streaming) displayDriver.displayText("Hold button\nto talk");
+        if (!streaming) showIdlePrompt();
     });
 
     // Push-to-talk on button 0 (the front button). Uses the 200ms default

--- a/src/ResidentSandbox.cpp
+++ b/src/ResidentSandbox.cpp
@@ -410,8 +410,8 @@ void Sandbox::loop() {
     _config.extensions.items[i]->update();
   }
 
-  // Lua tick + event dispatch only when an app is running.
-  if (!_appRunning) return;
+  // Lua tick + event dispatch only when an app is running and not suspended.
+  if (!_appRunning || _appSuspended) return;
 
   unsigned long now = millis();
   unsigned long elapsed = now - _lastTickTime;
@@ -425,6 +425,9 @@ void Sandbox::loop() {
 
 void Sandbox::loadApp(const char* luaCode)
 {
+  // A freshly loaded app starts running, never suspended.
+  _appSuspended = false;
+
   // Stop current app before loading new one
   if (_appRunning) {
     _appRunning = false;
@@ -461,6 +464,11 @@ void Sandbox::loadShader(const ShaderFields& fields) {
   loadApp(luaCode.c_str());
 }
 
+// Events received while the app is suspended are still queued onto the ring
+// here; loop() defers dispatch (processNextEvent) until resumeApp(), so they
+// are deferred — not dropped — though a long suspend can overflow the 8-slot
+// ring and lose the oldest. Gating on _appRunning (not _appSuspended) is
+// deliberate: a suspended app is still loaded and will see the events.
 void Sandbox::sendAppEvent(const char* name, const char* dataJson)
 {
   if (!_appRunning || !_onEventFuncRef) return;
@@ -470,6 +478,25 @@ void Sandbox::sendAppEvent(const char* name, const char* dataJson)
 bool Sandbox::isAppRunning() const
 {
   return _appRunning;
+}
+
+void Sandbox::suspendApp()
+{
+  if (!_appRunning || _appSuspended) return;
+  _appSuspended = true;
+  notifyAppRunning(false);  // free the status display for overlay text
+}
+
+void Sandbox::resumeApp()
+{
+  if (!_appRunning || !_appSuspended) return;
+  _appSuspended = false;
+  notifyAppRunning(true);   // re-suppress status display; app owns the screen
+}
+
+bool Sandbox::isAppSuspended() const
+{
+  return _appSuspended;
 }
 
 // --- Lua compilation ---

--- a/src/ResidentSandbox.h
+++ b/src/ResidentSandbox.h
@@ -53,6 +53,16 @@ public:
     // State queries
     bool isAppRunning() const;
 
+    // App suspend/resume. Pauses the Lua tick (on_tick + event dispatch)
+    // without unloading the app — Courier and extension update() keep running.
+    // While suspended the status display is freed (notifyAppRunning(false)) so
+    // displayText() can show e.g. a "Listening" overlay. Both are no-ops when
+    // no app is loaded. isAppRunning() stays true while suspended; suspension
+    // is a separate axis queried via isAppSuspended().
+    void suspendApp();
+    void resumeApp();
+    bool isAppSuspended() const;
+
     // Timezone — no-op on nullptr/empty. Success means ezTime resolved the
     // zone (either from its own cache or via one UDP lookup to
     // timezoned.rop.nl). Failure logs and leaves hasTimezone() == false.
@@ -112,6 +122,7 @@ public:
 private:
     struct lua_State* _lua = nullptr;
     bool _appRunning = false;
+    bool _appSuspended = false;
 
     // Timezone selected via registration's detectedTimezone. When
     // _hasTimezone is true, ctx.localtime_* and time.hour/minute/second read

--- a/test/unit/include/Arduino.h
+++ b/test/unit/include/Arduino.h
@@ -8,23 +8,51 @@
 #include <cstdio>
 #include <cstdarg>
 #include <cassert>
+#include <cctype>
 #include <string>
 
-// Arduino's String — aliased to std::string for native test builds. Headers
-// like ResidentSandboxConfig.h declare `std::map<String, String>` aliases
-// that need a String type at parse time (even if unused at runtime). This is
-// purely additive: Esp32Lua's Lua.cpp wrapper doesn't reference String, so
-// the alias can't regress existing Lua tests.
-using String = std::string;
+// Arduino's String — a thin std::string subclass for native test builds.
+// Headers like ResidentSandboxConfig.h declare `std::map<String, String>`
+// aliases that need a String type at parse time, and ResidentSandbox.cpp /
+// chipstring.h use the Arduino-only surface (numeric-with-base constructor,
+// toLowerCase, substring, isEmpty). Inheriting from std::string keeps the
+// std interop (comparisons, operator+, map ordering) that earlier tests
+// relied on when this was a plain alias.
+class String : public std::string {
+public:
+    String() = default;
+    String(const char* s) : std::string(s ? s : "") {}
+    String(const std::string& s) : std::string(s) {}
+    String(unsigned long long value, int base = 10) {
+        char buf[24];
+        snprintf(buf, sizeof(buf), base == 16 ? "%llx" : "%llu", value);
+        assign(buf);
+    }
+    unsigned int length() const { return (unsigned int)size(); }
+    bool isEmpty() const { return empty(); }
+    String substring(size_t from) const { return String(substr(from)); }
+    String substring(size_t from, size_t to) const {
+        return String(substr(from, to - from));
+    }
+    void toLowerCase() {
+        for (auto& c : *this) c = (char)tolower((unsigned char)c);
+    }
+};
+
+// Numeric base constants (Arduino.h defines these as macros)
+#define DEC 10
+#define HEX 16
 
 // GPIO constants
 static constexpr int OUTPUT      = 0x03;
 static constexpr int INPUT       = 0x01;
 static constexpr int INPUT_PULLUP = 0x05;
 
-// Stub timing — returns 0 by design; tests needing real elapsed time should
-// use the raw C clock API directly or inject a clock abstraction instead.
-inline unsigned long millis() { return 0; }
+// Stub timing — a settable fake clock. Defaults to 0 (the old fixed-zero
+// behavior); tests that need elapsed time (e.g. Sandbox's TICK_INTERVAL
+// gate) advance it directly: `testMillis() += 200;`. Reset it in setUp().
+inline unsigned long& testMillis() { static unsigned long now = 0; return now; }
+inline unsigned long millis() { return testMillis(); }
 
 // Stub GPIO
 inline void     pinMode(int, int)       {}

--- a/test/unit/include/Courier.h
+++ b/test/unit/include/Courier.h
@@ -8,12 +8,17 @@
 // header via PIO's lib_deps; native tests get this stub via -Iinclude
 // (already in build_flags).
 //
-// Only Courier::Config is needed at test-compile time: it's a POD passed by
-// value through Resident's SandboxConfig::network. Mirror new Courier::Config
-// fields here when they're added upstream. Last sync: courier 0.4.x — see
-// the upstream Courier.h struct Config (github.com/inanimate-tech/courier).
+// Courier::Config is a POD passed by value through Resident's
+// SandboxConfig::network. State / Client / WebSocketTransport mirror just
+// the type-shape ResidentSandbox.cpp compiles against; the Client methods
+// are no-ops because native tests run networkless (cfg.network unset means
+// Sandbox never constructs or calls into the Client at runtime). Mirror new
+// fields/methods here when they're added upstream. Last sync: courier 0.4.x
+// — see the upstream Courier.h (github.com/inanimate-tech/courier).
 #pragma once
 #include <cstdint>
+#include <functional>
+#include <ArduinoJson.h>
 
 namespace Courier {
 
@@ -35,6 +40,49 @@ struct Config {
          uint32_t dns2 = 0)
       : host(host), port(port), path(path), apName(apName),
         defaultTransport(defaultTransport), dns1(dns1), dns2(dns2) {}
+};
+
+// Connection states ResidentSandbox.cpp switches on. Values beyond these
+// exist upstream; the sandbox handles unknowns via `default:`.
+enum class State {
+  Idle,
+  WifiConnecting,
+  WifiConfiguring,
+  WifiConnected,
+  TransportsConnecting,
+  Connected,
+  Reconnecting,
+  ConnectionFailed,
+};
+
+class WebSocketTransport {
+public:
+  void setEndpoint(const char* host, uint16_t port, const char* path) {
+    (void)host; (void)port; (void)path;
+  }
+};
+
+class Client {
+public:
+  explicit Client(const Config& config) { (void)config; }
+
+  template <typename T>
+  T& transport(const char* name) {
+    (void)name;
+    static T instance;
+    return instance;
+  }
+
+  State getState() const { return State::Idle; }
+  bool isTimeSynced() const { return false; }
+  void setup() {}
+  void loop() {}
+  void setAPName(const char* name) { (void)name; }
+
+  void onMessage(std::function<void(const char*, const char*, JsonDocument&)>) {}
+  void onConnectionChange(std::function<void(State)>) {}
+  void onTransportsWillConnect(std::function<void()>) {}
+  void onConnected(std::function<void()>) {}
 };
 
 } // namespace Courier

--- a/test/unit/include/Esp.h
+++ b/test/unit/include/Esp.h
@@ -1,0 +1,13 @@
+// test/unit/include/Esp.h
+//
+// Minimal ESP class stub for native unit tests. chipstring.h calls
+// ESP.getEfuseMac() to derive the device ID; any stable nonzero value works.
+#pragma once
+#include <cstdint>
+
+struct EspClass {
+    uint64_t getEfuseMac() { return 0xA4CF1200CAFEULL; }
+};
+
+// Inline (C++17) so all TUs share one instance, like Arduino's global.
+inline EspClass ESP;

--- a/test/unit/include/ezTime.h
+++ b/test/unit/include/ezTime.h
@@ -1,0 +1,28 @@
+// test/unit/include/ezTime.h
+//
+// Minimal ezTime stub for native unit tests.
+//
+// The real <ezTime.h> needs Arduino networking (UDP lookups to
+// timezoned.rop.nl) and doesn't compile under the native PlatformIO env.
+// Resident::Sandbox only touches Timezone::setLocation/hour/minute/second
+// and the UTC global, so that's all that exists here. setLocation() returns
+// false: native tests run timezone-less (hasTimezone() stays false), which
+// matches a device before its first successful zone lookup.
+#pragma once
+#include <Arduino.h>
+
+class Timezone {
+public:
+    bool setLocation(const String& ianaZone) { (void)ianaZone; return false; }
+    int hour() { return 0; }
+    int minute() { return 0; }
+    int second() { return 0; }
+};
+
+// ezTime's built-in UTC instance. Inline (C++17) so all TUs share one.
+inline Timezone UTC;
+
+// Sync status — native tests run with time never synced (matches a device
+// before its first NTP exchange).
+enum timeStatus_t { timeNotSet, timeNeedsSync, timeSet };
+inline timeStatus_t timeStatus() { return timeNotSet; }

--- a/test/unit/platformio.ini
+++ b/test/unit/platformio.ini
@@ -13,3 +13,7 @@ build_flags =
     -I../../src
 lib_deps =
     fischer-simon/Esp32Lua@^5.4.7
+    # ArduinoJson is header-only and platform-independent; the real library
+    # satisfies ResidentSandbox.h's <ArduinoJson.h> include natively, so it
+    # isn't stubbed like Arduino/Courier/ezTime.
+    bblanchon/ArduinoJson@^7

--- a/test/unit/test/test_sandbox_suspend/test_sandbox_suspend.cpp
+++ b/test/unit/test/test_sandbox_suspend/test_sandbox_suspend.cpp
@@ -1,0 +1,219 @@
+// Behavioral tests for Sandbox::suspendApp() / resumeApp() / isAppSuspended().
+//
+// Compiles the real ResidentSandbox.cpp against the native stub set
+// (Arduino/Courier/ezTime/Esp in ../include, real ArduinoJson via lib_deps).
+// The sandbox runs networkless (no cfg.network), so no Courier::Client is
+// ever constructed — the stub Client only needs to satisfy the compiler.
+//
+// Observability: a SpyDriver extension records onAppRunning() notifications
+// (what frees/suppresses the status display on real hardware) and exposes a
+// `probe` Lua module the test app calls from on_tick/on_event, so tick and
+// event dispatch are counted from inside the Lua VM.
+#include <unity.h>
+#include <vector>
+
+#include "ResidentSandbox.cpp"
+
+namespace {
+
+class SpyDriver : public Resident::Driver {
+public:
+  int tickCount = 0;
+  int eventCount = 0;
+  int updateCount = 0;
+  std::vector<bool> appRunningCalls;
+  char lastEventName[32] = "";
+
+  const char* name() const override { return "probe"; }
+  void update() override { updateCount++; }
+  void onAppRunning(bool running) override { appRunningCalls.push_back(running); }
+
+  void registerModule(Resident::LuaModule& m) override {
+    m.method<SpyDriver, &SpyDriver::luaTick>("tick");
+    m.method<SpyDriver, &SpyDriver::luaEvent>("event");
+  }
+
+  int luaTick(lua_State* L) {
+    (void)L;
+    tickCount++;
+    return 0;
+  }
+  int luaEvent(lua_State* L) {
+    const char* n = lua_tostring(L, 1);
+    if (n) {
+      strncpy(lastEventName, n, sizeof(lastEventName) - 1);
+      lastEventName[sizeof(lastEventName) - 1] = '\0';
+    }
+    eventCount++;
+    return 0;
+  }
+};
+
+SpyDriver* spy = nullptr;
+Resident::Sandbox* sandbox = nullptr;
+
+constexpr const char* TEST_APP =
+    "function init(ctx) end\n"
+    "function on_tick(ctx, dt) probe.tick() end\n"
+    "function on_event(ctx, e) probe.event(e.name) end\n";
+
+// Advance the fake clock past TICK_INTERVAL (100ms) and run one loop()
+// iteration; each iteration fires at most one on_tick and dispatches at
+// most one queued event.
+void runLoop(int times = 1) {
+  for (int i = 0; i < times; i++) {
+    testMillis() += 200;
+    sandbox->loop();
+  }
+}
+
+}  // namespace
+
+void setUp(void) {
+  testMillis() = 0;
+  spy = new SpyDriver();
+  Resident::SandboxConfig cfg;
+  cfg.deviceType = "native-test";
+  cfg.extensions = {spy};
+  sandbox = new Resident::Sandbox(cfg);
+  sandbox->setup();
+}
+
+void tearDown(void) {
+  delete sandbox;
+  sandbox = nullptr;
+  delete spy;
+  spy = nullptr;
+}
+
+void test_suspend_resume_are_noops_without_app(void) {
+  TEST_ASSERT_FALSE(sandbox->isAppRunning());
+  TEST_ASSERT_FALSE(sandbox->isAppSuspended());
+
+  sandbox->suspendApp();
+  TEST_ASSERT_FALSE(sandbox->isAppSuspended());
+
+  sandbox->resumeApp();
+  TEST_ASSERT_FALSE(sandbox->isAppSuspended());
+
+  TEST_ASSERT_EQUAL_INT(0, (int)spy->appRunningCalls.size());
+}
+
+void test_loaded_app_starts_running_not_suspended(void) {
+  sandbox->loadApp(TEST_APP);
+
+  TEST_ASSERT_TRUE(sandbox->isAppRunning());
+  TEST_ASSERT_FALSE(sandbox->isAppSuspended());
+  TEST_ASSERT_EQUAL_INT(1, (int)spy->appRunningCalls.size());
+  TEST_ASSERT_TRUE(spy->appRunningCalls[0]);
+
+  runLoop();
+  TEST_ASSERT_EQUAL_INT(1, spy->tickCount);
+}
+
+void test_suspend_pauses_tick_but_extensions_keep_updating(void) {
+  sandbox->loadApp(TEST_APP);
+  runLoop();
+  TEST_ASSERT_EQUAL_INT(1, spy->tickCount);
+
+  sandbox->suspendApp();
+  TEST_ASSERT_TRUE(sandbox->isAppSuspended());
+  // Still loaded/running — suspension is a separate axis.
+  TEST_ASSERT_TRUE(sandbox->isAppRunning());
+  // Drivers were told the app stopped owning the screen.
+  TEST_ASSERT_FALSE(spy->appRunningCalls.back());
+
+  int updatesBefore = spy->updateCount;
+  runLoop(3);
+  TEST_ASSERT_EQUAL_INT(1, spy->tickCount);  // no further ticks
+  TEST_ASSERT_EQUAL_INT(updatesBefore + 3, spy->updateCount);
+}
+
+void test_resume_restores_tick_and_renotifies(void) {
+  sandbox->loadApp(TEST_APP);
+  sandbox->suspendApp();
+  runLoop(2);
+  TEST_ASSERT_EQUAL_INT(0, spy->tickCount);
+
+  sandbox->resumeApp();
+  TEST_ASSERT_FALSE(sandbox->isAppSuspended());
+  TEST_ASSERT_TRUE(spy->appRunningCalls.back());
+
+  runLoop();
+  TEST_ASSERT_EQUAL_INT(1, spy->tickCount);
+}
+
+void test_repeated_suspend_resume_notify_once(void) {
+  sandbox->loadApp(TEST_APP);
+  TEST_ASSERT_EQUAL_INT(1, (int)spy->appRunningCalls.size());  // [true]
+
+  sandbox->suspendApp();
+  sandbox->suspendApp();  // no-op: already suspended
+  TEST_ASSERT_EQUAL_INT(2, (int)spy->appRunningCalls.size());  // [true, false]
+
+  sandbox->resumeApp();
+  sandbox->resumeApp();  // no-op: not suspended
+  TEST_ASSERT_EQUAL_INT(3, (int)spy->appRunningCalls.size());  // [.., true]
+  TEST_ASSERT_TRUE(spy->appRunningCalls.back());
+}
+
+void test_events_deferred_while_suspended_dispatch_on_resume(void) {
+  sandbox->loadApp(TEST_APP);
+  sandbox->suspendApp();
+
+  // Queued while suspended: the app is still loaded, so the event is
+  // accepted — dispatch is what's gated.
+  sandbox->sendAppEvent("ping", "{}");
+  runLoop(2);
+  TEST_ASSERT_EQUAL_INT(0, spy->eventCount);
+
+  sandbox->resumeApp();
+  runLoop();
+  TEST_ASSERT_EQUAL_INT(1, spy->eventCount);
+  TEST_ASSERT_EQUAL_STRING("ping", spy->lastEventName);
+}
+
+void test_long_suspend_overflows_ring_dropping_oldest(void) {
+  sandbox->loadApp(TEST_APP);
+  sandbox->suspendApp();
+
+  // The 8-slot ring holds 7 events; queueing 10 drops the oldest 3.
+  char name[8];
+  for (int i = 1; i <= 10; i++) {
+    snprintf(name, sizeof(name), "e%d", i);
+    sandbox->sendAppEvent(name, "{}");
+  }
+
+  sandbox->resumeApp();
+  runLoop(10);
+  TEST_ASSERT_EQUAL_INT(7, spy->eventCount);
+  TEST_ASSERT_EQUAL_STRING("e10", spy->lastEventName);
+}
+
+void test_load_app_clears_suspension(void) {
+  sandbox->loadApp(TEST_APP);
+  sandbox->suspendApp();
+  TEST_ASSERT_TRUE(sandbox->isAppSuspended());
+
+  sandbox->loadApp(TEST_APP);
+  TEST_ASSERT_FALSE(sandbox->isAppSuspended());
+  TEST_ASSERT_TRUE(sandbox->isAppRunning());
+  TEST_ASSERT_TRUE(spy->appRunningCalls.back());
+
+  runLoop();
+  TEST_ASSERT_EQUAL_INT(1, spy->tickCount);
+}
+
+int main(int, char**) {
+  UNITY_BEGIN();
+  RUN_TEST(test_suspend_resume_are_noops_without_app);
+  RUN_TEST(test_loaded_app_starts_running_not_suspended);
+  RUN_TEST(test_suspend_pauses_tick_but_extensions_keep_updating);
+  RUN_TEST(test_resume_restores_tick_and_renotifies);
+  RUN_TEST(test_repeated_suspend_resume_notify_once);
+  RUN_TEST(test_events_deferred_while_suspended_dispatch_on_resume);
+  RUN_TEST(test_long_suspend_overflows_ring_dropping_oldest);
+  RUN_TEST(test_load_app_clears_suspension);
+  UNITY_END();
+  return 0;
+}


### PR DESCRIPTION
## What

Adds `Resident::Sandbox::suspendApp()` / `resumeApp()` / `isAppSuspended()`: pause a running app's Lua tick (`on_tick` + event dispatch) without unloading it. Courier and extension `update()` keep running. While suspended, drivers get `onAppRunning(false)` so the status display is freed for direct text — `resumeApp()` reverses it. Events arriving during suspension are queued (ring semantics apply), not dropped, and `loadApp` always clears suspension.

Also adds `DisplayDriver::repaint()` to the m5stick drivers lib, and m5stick-voice uses the pair to show "Listening" over the running app during push-to-talk (verified on M5StickC Plus2 hardware during the voice spike).

Rolled into the existing **v0.5.1-dev** changelog section.

## Tests

First native test coverage of `ResidentSandbox.cpp` itself — the stub set grows ezTime/Esp/Courier-client stubs, an Arduino `String` class, and a settable `millis()` clock (ArduinoJson comes in as a real lib_dep, it's platform-independent). 8 behavioral tests:

- suspend/resume are no-ops without an app
- a loaded app starts running, not suspended
- suspend pauses the tick while extensions keep updating
- resume restores the tick
- `onAppRunning` fires once per transition (idempotent repeats)
- events queued while suspended dispatch after resume
- a long suspend overflows the 8-slot ring, dropping oldest
- `loadApp` clears suspension

## Verification

- `./tools/run-tests.py unit` — 28/28 pass (20 existing + 8 new)
- `./tools/run-tests.py static-analysis` — clean
- `pio run` for `examples/m5stick-demo/device` and `examples/m5stick-voice/device` — both build

🤖 Generated with [Claude Code](https://claude.com/claude-code)