### PR TITLE
feat(sandbox): unified driver lifecycle & two-cadence update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ examples/*/docs/superpowers/
 
 # Local pack output (pio pkg pack / compote component pack)
 dist/
+
+# Superpowers subagent-driven-development scratch (briefs, review packages, ledger)
+.superpowers/

--- a/docs/api.md
+++ b/docs/api.md
@@ -666,7 +666,7 @@ Calls `Sandbox::clearPersistedApp()`. The next boot will not restore any app. Eq
 
 The last app (or shader) that loads successfully — compiles **and** runs `init()` without error — is saved to flash (NVS) and auto-reloaded on the next boot.
 
-On boot, if a saved app exists, the device shows its identity and a 20-second countdown on the status display before loading it:
+Once the device is reachable — **connected**, or immediately in standalone mode — if a saved app exists the status display shows the device identity with a 20-second countdown before loading it (while connecting, the usual connection-status text shows instead). A networked device that never connects stays on the connection screen and does not auto-load.
 
 ```
 Device ID: <deviceId>

--- a/docs/api.md
+++ b/docs/api.md
@@ -103,19 +103,17 @@ sandbox.loop();    // call from Arduino loop()
    1. The user-registered `onConfigureNetwork(cb)` fires (if any), receiving the `Courier::Client&`. Use this to configure transports, register additional transports, or set TLS certificates.
    2. Resident's internal Courier hooks are wired (status-display / status-LED updates, reserved-type message routing).
    3. WiFiManager AP name is set to `"Resident <DeviceType> <id-suffix>"`.
-   4. The `StatusDisplay::begin()` lifecycle runs (if a `statusDisplay` is configured).
-   5. The sandbox itself initialises: Lua state is created, extensions get `begin()` and `registerModule()` calls in registration order, globals are registered.
-   6. `Courier::Client::setup()` runs, which kicks WiFi and transports. During this:
+   4. The sandbox initialises: Lua state is created, then Resident builds a de-duplicated lifecycle list of all managed objects — the `extensions[]` entries plus any role-slot peripherals (`statusDisplay`, `statusLED`, `systemButton`). Each object in that list receives `begin()` and `registerModule()` exactly once (idempotent), in registration order. Globals are registered.
+   5. `Courier::Client::setup()` runs, which kicks WiFi and transports. During this:
       - `onCourierConnectionChange` fires for each state transition (`WifiConnecting` → `WifiConnected` → `TransportsConnecting` → `Connected`, etc.). Internal handler updates `statusDisplay`/`statusLED`, then the user's `onConnectionChange(cb)` callback fires.
       - `onCourierTransportsWillConnect` fires once before transports begin. Internal handler sets the default `/agents/<type>-agent/<id>` WS path, then the user's `onTransportsWillConnect(cb)` callback fires (override the path here).
       - `onCourierConnected` fires when fully connected. The user's `onConnected(cb)` callback runs.
 3. **`loop()`** — in order:
    1. `Courier::Client::loop()` drives the network state machine and reads transports.
-   2. `StatusDisplay::update()` (if configured).
-   3. If networked, gates the Lua tick on `isConnected()`. Standalone always ticks.
-   4. Every extension's `update()` runs at full main-loop rate.
-   5. The Lua `on_tick(ctx, dt_ms)` callback fires at 10 FPS (100 ms interval).
-   6. Up to one pending event is delivered to `on_event(ctx, event)`.
+   2. **Driver heartbeat:** the de-duplicated lifecycle list is walked once and `update()` is called on each object. Role peripherals (`statusDisplay`, `statusLED`, `systemButton`) update every loop regardless of app state or connectivity. All other extensions update only while an app is loaded (running or suspended). Connectivity does not gate either cadence.
+   3. If a persisted app is waiting to load, the boot countdown runs (and the function returns early).
+   4. The Lua `on_tick(ctx, dt_ms)` callback fires at 10 FPS (100 ms interval) — only while an app is Running, and (when networked) only once connected. Standalone always ticks unconditionally.
+   5. Up to one pending event is delivered to `on_event(ctx, event)`.
 
 ### Setup-phase callbacks (register before `setup()`)
 
@@ -486,7 +484,7 @@ public:
 |--------|---------|-------------|
 | `solidColor(uint32_t color)` | *(pure virtual)* | Set the LED to a packed `0xRRGGBB` color — called by Resident's internal handler on connection state changes |
 
-Resident's internal handler calls `solidColor` automatically as the connection state changes (yellow during WiFi setup, cyan while transports connect, green when connected, orange while reconnecting, red on failure). There are no `begin()` or `update()` lifecycle hooks — initialize LED hardware in your subclass constructor or before `sandbox.setup()`.
+Resident's internal handler calls `solidColor` automatically as the connection state changes (yellow during WiFi setup, cyan while transports connect, green when connected, orange while reconnecting, red on failure). `StatusLED` is a `Driver` subclass and therefore inherits the standard `Driver` lifecycle: `begin()` is called once during `Sandbox::setup()` and `update()` is called every loop (both default to no-ops). Override `begin()` to initialize LED hardware there rather than in the constructor.
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -344,6 +344,30 @@ This matters because `LuaModule::method<>` casts the stored `Extension*` pointer
 - Use `Extension` when you only register a Lua module (read sensors, control outputs from Lua, but no driver-generated events).
 - Use `Driver` when your extension needs to push events into Lua (`sendEvent`) or respond to app start/stop (`onAppRunning`).
 
+### Driver lifecycle and update cadence
+
+Every object Resident manages — sandbox extensions and the device-role
+peripherals (status display, system button, status LED) — is a `Driver`
+(hence an `Extension`). `begin()` runs once for each at setup. `update()`
+runs on a single de-duplicated list every loop:
+
+- **Role peripherals** (whatever you assign to `config.statusDisplay` /
+  `statusLED` / `systemButton`) update **every loop, always** — so the status
+  screen and system button work before any app exists and across a brief
+  reconnect.
+- **Other extensions** update **only while an app is loaded** (running or
+  suspended).
+- **Connectivity gates neither** `update()`. (The Lua `on_tick` still waits
+  for the first connection on networked boards.)
+
+A driver fills a device role by implementing the role interface (`StatusDisplay`
+/ `SystemButton` / `StatusLED`, each a `Driver` subclass) — that's the
+*capability*. Whether it's *used* in that role is the per-device config slot,
+so the same driver is reusable across boards. An object fills at most one role.
+
+Driver events (`sendEvent`) are delivered to the app only while an app is
+loaded; emitted with no app loaded, they are dropped.
+
 ---
 
 ## Resident::LuaModule

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,9 @@
   from one de-duplicated list: `begin()` once; `update()` every loop for
   role peripherals and (only while an app is loaded) for other extensions,
   independent of connectivity. Driver events are dropped when no app is loaded.
+  **Migration:** any custom `StatusDisplay`, `SystemButton`, or `StatusLED`
+  implementation must now also implement `Driver::name()` (a pure virtual
+  returning a `const char*` identifier).
 
 ### Fixes
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,12 @@
   `StatusDisplay::displayText()`. The m5stick-voice example uses it to show
   "Listening" over a running app during push-to-talk.
 
+- **Unified driver lifecycle.** Role interfaces (`StatusDisplay`,
+  `SystemButton`, `StatusLED`) are now `Driver` subclasses. Lifecycle is driven
+  from one de-duplicated list: `begin()` once; `update()` every loop for
+  role peripherals and (only while an app is loaded) for other extensions,
+  independent of connectivity. Driver events are dropped when no app is loaded.
+
 ### Fixes
 
 - **Lua allocator falls back to internal RAM on boards without PSRAM** (e.g. ESP32-S3FN8 / M5Dial). Previously every Lua allocation went to `MALLOC_CAP_SPIRAM`, which returns NULL when no PSRAM exists — the Lua runtime had no usable heap and every app failed with "not enough memory". The capability is now resolved once on first use: SPIRAM when present, internal 8-bit RAM otherwise. Boards with PSRAM are unaffected.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,6 +26,13 @@
   implementation must now also implement `Driver::name()` (a pure virtual
   returning a `const char*` identifier).
 
+- **Boot identity screen now waits for connectivity.** A networked device shows
+  its connection status while connecting, then — once **connected** — the
+  identity screen and (if an app is persisted) the 20-second countdown. A
+  device that never connects stays on the connection screen and does not
+  auto-load. Standalone devices show the identity/countdown immediately at
+  setup, as before.
+
 ### Fixes
 
 - **Lua allocator falls back to internal RAM on boards without PSRAM** (e.g. ESP32-S3FN8 / M5Dial). Previously every Lua allocation went to `MALLOC_CAP_SPIRAM`, which returns NULL when no PSRAM exists — the Lua runtime had no usable heap and every app failed with "not enough memory". The capability is now resolved once on first use: SPIRAM when present, internal 8-bit RAM otherwise. Boards with PSRAM are unaffected.

--- a/examples/adafruit-esp32-s2-feather/device-minimal-resident/src/main.cpp
+++ b/examples/adafruit-esp32-s2-feather/device-minimal-resident/src/main.cpp
@@ -21,6 +21,8 @@ static bool batteryReady = false;
 // the device id, which is what the user needs to push apps. We draw it big.
 class TFTStatusDisplay : public Resident::StatusDisplay {
 public:
+  const char* name() const override { return "screen"; }
+
   void begin() override {
     tft.fillScreen(ST77XX_BLACK);
     tft.setTextWrap(false);

--- a/examples/adafruit-esp32-s2-feather/device/lib/drivers/src/DisplayDriver.cpp
+++ b/examples/adafruit-esp32-s2-feather/device/lib/drivers/src/DisplayDriver.cpp
@@ -20,7 +20,6 @@ void DisplayDriver::begin() {
   ledcSetup(BACKLIGHT_LEDC_CH, 5000, 8);  // 5 kHz, 8-bit
   ledcAttachPin(_backlitePin, BACKLIGHT_LEDC_CH);
   ledcWrite(BACKLIGHT_LEDC_CH, 255);
-  _spriteReady = true;
 }
 
 void DisplayDriver::displayText(const char* text) {

--- a/examples/adafruit-esp32-s2-feather/device/lib/drivers/src/DisplayDriver.cpp
+++ b/examples/adafruit-esp32-s2-feather/device/lib/drivers/src/DisplayDriver.cpp
@@ -13,7 +13,6 @@ static constexpr uint16_t toRGB565(int r, int g, int b) {
 }
 
 void DisplayDriver::begin() {
-  if (_initialized) return;  // dual-inherit (Driver + StatusDisplay) → guard
   // Canvas matches the TFT's post-rotation logical size (set in main.cpp
   // before handing off to Resident, so width()/height() reflect rotation).
   _canvas = new GFXcanvas16(_tft->width(), _tft->height());
@@ -21,7 +20,7 @@ void DisplayDriver::begin() {
   ledcSetup(BACKLIGHT_LEDC_CH, 5000, 8);  // 5 kHz, 8-bit
   ledcAttachPin(_backlitePin, BACKLIGHT_LEDC_CH);
   ledcWrite(BACKLIGHT_LEDC_CH, 255);
-  _initialized = true;
+  _spriteReady = true;
 }
 
 void DisplayDriver::displayText(const char* text) {

--- a/examples/adafruit-esp32-s2-feather/device/lib/drivers/src/DisplayDriver.h
+++ b/examples/adafruit-esp32-s2-feather/device/lib/drivers/src/DisplayDriver.h
@@ -49,7 +49,6 @@ private:
   Adafruit_ST7789* _tft;
   uint8_t _backlitePin;
   GFXcanvas16* _canvas = nullptr;
-  bool _spriteReady = false;
   bool _appRunning = false;
 
   int clear(lua_State* L);

--- a/examples/adafruit-esp32-s2-feather/device/lib/drivers/src/DisplayDriver.h
+++ b/examples/adafruit-esp32-s2-feather/device/lib/drivers/src/DisplayDriver.h
@@ -7,13 +7,10 @@
 #include <Adafruit_GFX.h>
 #include <Adafruit_ST7789.h>
 
-// Resident driver wrapping Adafruit_ST7789 for Lua access via the `screen.*`
-// module. Dual role: Resident::Driver (Lua surface against an off-screen
-// GFXcanvas16) + Resident::StatusDisplay (connection-state text written
-// straight to the TFT, suppressed while a Lua app is running).
-//
-// The PWM channel for TFT_BACKLITE is owned here so `screen.set_brightness`
-// can control it.
+// A StatusDisplay (which is a Driver): renders Lua screen.* via an off-screen
+// GFXcanvas16 and writes connection-state text straight to the TFT, suppressed
+// while a Lua app is running. Owns the PWM channel for TFT_BACKLITE so
+// screen.set_brightness can control it.
 class DisplayDriver : public Resident::StatusDisplay {
 public:
   DisplayDriver(Adafruit_ST7789* tft, uint8_t backlitePin)
@@ -52,7 +49,7 @@ private:
   Adafruit_ST7789* _tft;
   uint8_t _backlitePin;
   GFXcanvas16* _canvas = nullptr;
-  bool _initialized = false;
+  bool _spriteReady = false;
   bool _appRunning = false;
 
   int clear(lua_State* L);

--- a/examples/adafruit-esp32-s2-feather/device/lib/drivers/src/DisplayDriver.h
+++ b/examples/adafruit-esp32-s2-feather/device/lib/drivers/src/DisplayDriver.h
@@ -14,7 +14,7 @@
 //
 // The PWM channel for TFT_BACKLITE is owned here so `screen.set_brightness`
 // can control it.
-class DisplayDriver : public Resident::Driver, public Resident::StatusDisplay {
+class DisplayDriver : public Resident::StatusDisplay {
 public:
   DisplayDriver(Adafruit_ST7789* tft, uint8_t backlitePin)
       : _tft(tft), _backlitePin(backlitePin) {}

--- a/examples/adafruit-esp32-s2-feather/device/lib/drivers/src/LEDDriver.h
+++ b/examples/adafruit-esp32-s2-feather/device/lib/drivers/src/LEDDriver.h
@@ -15,7 +15,7 @@
 // Once an app is running, `solidColor()` no-ops so the app fully owns
 // the pixel. The Adafruit_NeoPixel must already be `begin()`'d in
 // main.cpp before Resident::Device::setup() runs.
-class LEDDriver : public Resident::Driver, public Resident::StatusLED {
+class LEDDriver : public Resident::StatusLED {
 public:
   explicit LEDDriver(Adafruit_NeoPixel* pixel) : _pixel(pixel) {}
 

--- a/examples/adafruit-esp32-s2-feather/device/lib/drivers/src/LEDDriver.h
+++ b/examples/adafruit-esp32-s2-feather/device/lib/drivers/src/LEDDriver.h
@@ -6,15 +6,12 @@
 #include <ResidentStatusLED.h>
 #include <Adafruit_NeoPixel.h>
 
-// Resident driver for the single onboard NeoPixel. Dual role:
-//   - Resident::Driver       → exposes the `led.*` Lua module
-//   - Resident::StatusLED    → Resident drives the pixel for connection
-//                              state (yellow=connecting, cyan=transports,
-//                              green=connected, orange=reconnecting,
-//                              red=failed) until a Lua app loads.
-// Once an app is running, `solidColor()` no-ops so the app fully owns
-// the pixel. The Adafruit_NeoPixel must already be `begin()`'d in
-// main.cpp before Resident::Device::setup() runs.
+// A StatusLED (which is a Driver): exposes the `led.*` Lua module and drives
+// the onboard NeoPixel for connection state (yellow=connecting,
+// cyan=transports, green=connected, orange=reconnecting, red=failed) until a
+// Lua app loads. solidColor() no-ops once an app is running so the app fully
+// owns the pixel. The Adafruit_NeoPixel must already be begin()'d in
+// main.cpp before Sandbox::setup() runs.
 class LEDDriver : public Resident::StatusLED {
 public:
   explicit LEDDriver(Adafruit_NeoPixel* pixel) : _pixel(pixel) {}

--- a/examples/m5stick-demo/device/lib/drivers/src/DisplayDriver.cpp
+++ b/examples/m5stick-demo/device/lib/drivers/src/DisplayDriver.cpp
@@ -11,14 +11,11 @@ extern "C" {
 #endif
 
 void DisplayDriver::begin() {
-  if (_initialized) return;   // dual-inherit (Driver + StatusDisplay) →
-                              // Device.setup() and Sandbox.initialize()
-                              // both reach us; guard against re-init.
   // setColorDepth must come BEFORE createSprite — the sprite buffer is
   // allocated at whatever depth is set when create is called.
   _canvas.setColorDepth(16);
   _canvas.createSprite(M5.Display.width(), M5.Display.height());
-  _initialized = true;
+  _spriteReady = true;
 }
 
 void DisplayDriver::displayText(const char* text) {
@@ -28,7 +25,7 @@ void DisplayDriver::displayText(const char* text) {
   // directly to M5.Display (fillScreen + print) blacks out the panel between
   // the clear and the redraw, which flickers visibly when the text updates
   // frequently — e.g. the once-a-second boot countdown.
-  if (!_initialized) {              // sprite not allocated yet (pre-begin)
+  if (!_spriteReady) {              // sprite not allocated yet (pre-begin)
     M5.Display.fillScreen(TFT_BLACK);
     return;
   }
@@ -44,11 +41,11 @@ void DisplayDriver::displayText(const char* text) {
 }
 
 void DisplayDriver::repaint() {
-  if (_initialized) _canvas.pushSprite(0, 0);
+  if (_spriteReady) _canvas.pushSprite(0, 0);
 }
 
 void DisplayDriver::onAppReset() {
-  if (_initialized) {
+  if (_spriteReady) {
     _canvas.fillScreen(TFT_BLACK);
     _canvas.pushSprite(0, 0);
   } else {

--- a/examples/m5stick-demo/device/lib/drivers/src/DisplayDriver.h
+++ b/examples/m5stick-demo/device/lib/drivers/src/DisplayDriver.h
@@ -10,7 +10,7 @@
 // Dual role: Resident::Driver (Lua screen.* module via sprite buffer)
 //          + Resident::StatusDisplay (connection state text, direct to display)
 // When an app is running, status display calls are suppressed.
-class DisplayDriver : public Resident::Driver, public Resident::StatusDisplay {
+class DisplayDriver : public Resident::StatusDisplay {
 public:
   const char* name() const override { return "screen"; }
 

--- a/examples/m5stick-demo/device/lib/drivers/src/DisplayDriver.h
+++ b/examples/m5stick-demo/device/lib/drivers/src/DisplayDriver.h
@@ -6,10 +6,9 @@
 #include <ResidentStatusDisplay.h>
 #include <M5Unified.h>
 
-// Resident driver wrapping M5.Display for Lua access.
-// Dual role: Resident::Driver (Lua screen.* module via sprite buffer)
-//          + Resident::StatusDisplay (connection state text, direct to display)
-// When an app is running, status display calls are suppressed.
+// A StatusDisplay (which is a Driver): renders Lua screen.* via an off-screen
+// sprite and writes connection-state text directly to the display. Status
+// display calls are suppressed while an app is running.
 class DisplayDriver : public Resident::StatusDisplay {
 public:
   const char* name() const override { return "screen"; }
@@ -51,7 +50,7 @@ protected:
   M5Canvas _canvas{&M5.Display};
 
 private:
-  bool _initialized = false;
+  bool _spriteReady = false;
   bool _appRunning = false;
 
   int clear(lua_State* L);

--- a/examples/m5stick-demo/device/lib/drivers/src/PushButtonsDriver.cpp
+++ b/examples/m5stick-demo/device/lib/drivers/src/PushButtonsDriver.cpp
@@ -57,23 +57,27 @@ void PushButtonsDriver::update()
       }
     }
 
-    // Release detection (LOW → HIGH)
+    // Release detection (LOW → HIGH), debounced so contact chatter mid-hold
+    // can't momentarily read "released".
     if (current == HIGH && btn.lastState == LOW) {
-      if (btn.isDown) {
-        if (btn.longPressTriggered) {
-          if (_longPress[i].callback) {
-            _longPress[i].callback(false);
+      if (now - btn.lastDebounceTime > DEBOUNCE_MS) {
+        btn.lastDebounceTime = now;
+        if (btn.isDown) {
+          if (btn.longPressTriggered) {
+            if (_longPress[i].callback) {
+              _longPress[i].callback(false);
+            }
+          } else {
+            btn.pressCount++;
+            Resident::EventField fields[] = {
+              {"index", Resident::EventField::INT, {.i = (int)i}},
+              {"count", Resident::EventField::INT, {.i = (int)btn.pressCount}}
+            };
+            sendEvent("button", fields, 2);
+            Serial.printf("PushButton[%d] pressed (count=%d)\n", i, btn.pressCount);
           }
-        } else {
-          btn.pressCount++;
-          Resident::EventField fields[] = {
-            {"index", Resident::EventField::INT, {.i = (int)i}},
-            {"count", Resident::EventField::INT, {.i = (int)btn.pressCount}}
-          };
-          sendEvent("button", fields, 2);
-          Serial.printf("PushButton[%d] pressed (count=%d)\n", i, btn.pressCount);
+          btn.isDown = false;
         }
-        btn.isDown = false;
       }
     }
 
@@ -83,20 +87,10 @@ void PushButtonsDriver::update()
 
 bool PushButtonsDriver::pressed()
 {
-  if (_config.numButtons == 0) return _sysStable;
-
-  // Read button 0 directly (active-low, INPUT_PULLUP). This is independent of
-  // update() so it stays live during the boot countdown; debounce it here.
-  bool raw = (digitalRead(_config.pins[0]) == LOW);
-  unsigned long now = millis();
-  if (raw != _sysRawLast) {
-    _sysRawLast = raw;
-    _sysRawChangedAt = now;
-  }
-  if (now - _sysRawChangedAt >= DEBOUNCE_MS) {
-    _sysStable = raw;
-  }
-  return _sysStable;
+  // Debounced held-level of button 0, maintained by update() (which the
+  // runtime now calls every loop while this is the system button — including
+  // during the boot countdown).
+  return _buttons[0].isDown;
 }
 
 void PushButtonsDriver::setLongPress(uint8_t buttonIndex, LongPressFn callback,

--- a/examples/m5stick-demo/device/lib/drivers/src/PushButtonsDriver.h
+++ b/examples/m5stick-demo/device/lib/drivers/src/PushButtonsDriver.h
@@ -28,8 +28,8 @@ public:
 
   int pressCount(lua_State* L);
 
-  // Resident::SystemButton — level read of button 0. Self-debounced so it
-  // works during the boot countdown, when the Driver's update() isn't called.
+  // Resident::SystemButton — debounced held-level of button 0, maintained by
+  // update() (called every loop while this is the system button).
   bool pressed() override;
 
   uint16_t getTotalPressCount() const;
@@ -61,11 +61,6 @@ private:
   };
   LongPressConfig _longPress[MAX_BUTTONS];
 
-  // Independent debounce for the SystemButton level read (pressed()), since it
-  // is polled outside the update() cycle during the boot countdown.
-  bool _sysRawLast = false;
-  unsigned long _sysRawChangedAt = 0;
-  bool _sysStable = false;
 };
 
 #endif // PUSH_BUTTONS_DRIVER_H

--- a/examples/m5stick-demo/device/lib/drivers/src/PushButtonsDriver.h
+++ b/examples/m5stick-demo/device/lib/drivers/src/PushButtonsDriver.h
@@ -14,7 +14,7 @@ struct PushButtonsConfig {
 // Also acts as the Resident::SystemButton (button 0 — the front button), so the
 // runtime can read it directly during the boot countdown (tap = load now, long
 // press = forget the saved app), independent of the app-facing button events.
-class PushButtonsDriver : public Resident::Driver, public Resident::SystemButton {
+class PushButtonsDriver : public Resident::SystemButton {
 public:
   explicit PushButtonsDriver(const PushButtonsConfig& config);
 

--- a/src/ResidentSandbox.cpp
+++ b/src/ResidentSandbox.cpp
@@ -322,32 +322,20 @@ void Sandbox::setup()
   }
 #endif
 
-  // Arm the boot countdown if a previously-saved app exists.
+  // Load any persisted app source. It is not armed here — the identity screen
+  // and its countdown appear only once the device is ready to show them: on
+  // first connection (networked), or right below (standalone). A networked
+  // device that never connects stays on the connection-status screen.
   if (_config.persistApps && _store) {
     _pendingPersistedSource = _store->load();
-    if (!_pendingPersistedSource.isEmpty()) {
-      if (_config.statusDisplay) {
-        // The countdown's sole purpose is to show the device ID on the display.
-        // Only arm it when there is a display to show it on.
-        _runState = RunState::Pending;
-        _countdownStartMs = millis();
-        _lastCountdownSecondShown = -1;
-      } else {
-        // No display — nothing to show, no reason to stall. Restore immediately.
-        finishBootCountdown();
-      }
-    }
   }
 
-  // 6. Kick off Courier (WiFi + transports).
+  // 6. Kick off Courier (WiFi + transports). The idle screen is then shown on
+  // first connection. Standalone has no connection step, so enter it now.
   if (_courier.has_value()) {
     _courier->setup();
-  }
-
-  // Standalone (no network): no Connected event will arrive to paint the
-  // Ready identity screen, so paint it now when idle.
-  if (!_courier.has_value() && _runState == RunState::Ready) {
-    showReadyScreen();
+  } else {
+    enterIdleScreen();
   }
 }
 
@@ -424,7 +412,7 @@ void Sandbox::onCourierConnectionChange(Courier::State state)
       }
       case S::WifiConnected:         showStatusText("WiFi connected"); break;
       case S::TransportsConnecting:  showStatusText("Connecting..."); break;
-      case S::Connected:             if (_runState == RunState::Ready) showIdentityScreen(); break;
+      case S::Connected:             enterIdleScreen(); break;
       case S::Reconnecting:          showStatusText("Reconnecting..."); break;
       case S::ConnectionFailed:      showStatusText("Connection failed"); break;
       default: break;
@@ -482,6 +470,28 @@ void Sandbox::showIdentityScreen(int countdownSecs)
              _deviceId.c_str(), getDeviceType());
   }
   showStatusText(buf);
+}
+
+void Sandbox::enterIdleScreen()
+{
+  // Called when the device is ready to present its idle UI. With a persisted
+  // app: show the identity screen + 20s countdown (then load), or restore
+  // immediately when there's no display to count down on. With no persisted
+  // app: rest on the identity screen. No-op once an app is loaded or counting
+  // down (so a reconnect doesn't re-arm or repaint over a running app).
+  if (_runState != RunState::Ready) return;
+
+  if (_pendingPersistedSource.isEmpty()) {
+    showReadyScreen();
+    return;
+  }
+  if (_config.statusDisplay) {
+    _runState = RunState::Pending;
+    _countdownStartMs = millis();
+    _lastCountdownSecondShown = -1;
+  } else {
+    finishBootCountdown();   // no display — nothing to count down on; restore now
+  }
 }
 
 void Sandbox::showReadyScreen()
@@ -829,8 +839,7 @@ bool Sandbox::compileApp(const char* code)
   notifyAppRunning(true);
   _lastInitOk = callInit();
 
-  Serial.println("Resident::Sandbox: app compiled successfully");
-  return true;
+  return true;   // loadAppInternal logs + emits the app_compiled telemetry
 }
 
 bool Sandbox::callInit()

--- a/src/ResidentSandbox.cpp
+++ b/src/ResidentSandbox.cpp
@@ -1066,6 +1066,11 @@ void Sandbox::driverEventHandler(void* ctx, const char* name,
 {
   Sandbox* self = (Sandbox*)ctx;
 
+  // Accept events only while an app is loaded (Running or Suspended). In
+  // Suspended they are queued and dispatched on resume (loop() gates dispatch
+  // on Running); in Ready/Pending there is no app, so drop them.
+  if (!self->isAppRunning()) return;
+
   // Count button events for ctx.trigger_count
   if (strcmp(name, "button") == 0) {
     self->_triggerCount++;

--- a/src/ResidentSandbox.cpp
+++ b/src/ResidentSandbox.cpp
@@ -191,9 +191,12 @@ void Sandbox::initialize()
 
   setupLuaEnvironment();
 
-  // Build the de-duped lifecycle set (extensions[] + role slots), then walk it:
-  // begin (idempotent), wire event sink if Driver, build Lua module table.
+  // Build the de-duped lifecycle set (extensions[] + role slots).
   buildLifecycleSet();
+
+  // Pass 1 — Lifecycle: wire event sink (so begin() can safely sendEvent()),
+  // then begin(). Covers all managed objects: declared extensions and any
+  // role-slot peripherals not also in extensions[].
   for (uint8_t i = 0; i < _lifecycleCount; i++) {
     Extension* ext = _lifecycle[i];
     Serial.printf("  Initializing extension: %s\n", ext->name());
@@ -205,9 +208,15 @@ void Sandbox::initialize()
     }
 
     Extension::beginExtension(*ext);
+  }
 
-    // Register Lua module: push fresh table, let extension populate it,
-    // setglobal under the extension's name.
+  // Pass 2 — Lua modules: register globals for declared extensions only.
+  // A role-slot peripheral that is NOT in extensions[] (e.g. a TFTStatusDisplay
+  // assigned only to cfg.statusDisplay) must NOT get a Lua global — it has no
+  // API surface to expose. A role object that also wants a Lua module must be
+  // listed in extensions[] explicitly.
+  for (uint8_t i = 0; i < _config.extensions.count; i++) {
+    Extension* ext = _config.extensions.items[i];
     lua_newtable(_lua);
     LuaModule m(_lua, ext);
     ext->registerModule(m);
@@ -541,7 +550,9 @@ bool Sandbox::loadAppInternal(const char* luaCode, bool persistOnSuccess)
     notifyAppRunning(false);
   }
 
-  // Reset extensions
+  // Reset extensions (declared extensions only, not slot-only peripherals).
+  // onAppReset() is an app-facing hook; slot-only peripherals are begun/updated
+  // via the lifecycle set but deliberately don't receive app lifecycle events.
   for (uint8_t i = 0; i < _config.extensions.count; i++) {
     _config.extensions.items[i]->onAppReset();
   }
@@ -1109,6 +1120,9 @@ void Sandbox::driverEventHandler(void* ctx, const char* name,
 }
 
 void Sandbox::notifyAppRunning(bool running) {
+  // Declared extensions only — same intentional carve-out as onAppReset():
+  // slot-only peripherals are begun/updated via the lifecycle set but don't
+  // receive app-facing hooks (onAppRunning / onAppReset).
   for (uint8_t i = 0; i < _config.extensions.count; i++) {
     Driver* driver = _config.extensions.items[i]->asDriver();
     if (driver) driver->onAppRunning(running);

--- a/src/ResidentSandbox.cpp
+++ b/src/ResidentSandbox.cpp
@@ -131,6 +131,38 @@ int Sandbox::luaGlobalIntForTest(const char* name)
 }
 
 
+void Sandbox::addLifecycle(Extension* e)
+{
+  if (!e) return;
+  for (uint8_t i = 0; i < _lifecycleCount; i++) {
+    if (_lifecycle[i] == e) return;   // already present — de-dup
+  }
+  if (_lifecycleCount < (Extensions::MAX + 3)) {
+    _lifecycle[_lifecycleCount++] = e;
+  }
+}
+
+void Sandbox::buildLifecycleSet()
+{
+  _lifecycleCount = 0;
+  for (uint8_t i = 0; i < _config.extensions.count; i++) {
+    addLifecycle(_config.extensions.items[i]);
+  }
+  // Role slots are Driver subclasses, so they upcast to Extension*. Append any
+  // not already in extensions[] so an assigned-but-unlisted peripheral is
+  // still begun and updated.
+  addLifecycle(_config.statusDisplay);
+  addLifecycle(_config.statusLED);
+  addLifecycle(_config.systemButton);
+}
+
+bool Sandbox::isPeripheral(Extension* e) const
+{
+  return e == static_cast<Extension*>(_config.statusDisplay)
+      || e == static_cast<Extension*>(_config.statusLED)
+      || e == static_cast<Extension*>(_config.systemButton);
+}
+
 void Sandbox::initialize()
 {
   Serial.println("Initializing Resident::Sandbox");
@@ -159,10 +191,11 @@ void Sandbox::initialize()
 
   setupLuaEnvironment();
 
-  // Walk extensions in registration order: begin (idempotent), wire
-  // event sink if Driver, build Lua module table.
-  for (uint8_t i = 0; i < _config.extensions.count; i++) {
-    Extension* ext = _config.extensions.items[i];
+  // Build the de-duped lifecycle set (extensions[] + role slots), then walk it:
+  // begin (idempotent), wire event sink if Driver, build Lua module table.
+  buildLifecycleSet();
+  for (uint8_t i = 0; i < _lifecycleCount; i++) {
+    Extension* ext = _lifecycle[i];
     Serial.printf("  Initializing extension: %s\n", ext->name());
 
     // Wire event sink first so a Driver's begin() can safely sendEvent().
@@ -266,10 +299,7 @@ void Sandbox::setup()
                   getDeviceType(), _deviceId.c_str());
   }
 
-  // 4. Status display starts up regardless of network.
-  if (_config.statusDisplay) _config.statusDisplay->begin();
-
-  // 5. Sandbox internals (Lua state, extensions). Always.
+  // 4. Sandbox internals (Lua state, extensions + role slots). Always.
   initialize();
 
   // Explicit override wins; otherwise use the platform default (NVS on

--- a/src/ResidentSandbox.cpp
+++ b/src/ResidentSandbox.cpp
@@ -488,29 +488,27 @@ void Sandbox::loop() {
   if (_courier.has_value()) {
     _courier->loop();
   }
-  if (_config.statusDisplay) _config.statusDisplay->update();
+  if (!_lua) return;
+
+  // Driver heartbeat — single de-duped walk, connectivity-independent.
+  // Peripherals (role-assigned) update every loop; other extensions only
+  // while an app is loaded (Running or Suspended).
+  for (uint8_t i = 0; i < _lifecycleCount; i++) {
+    Extension* e = _lifecycle[i];
+    if (isPeripheral(e) || isAppRunning()) {
+      e->update();
+    }
+  }
 
   if (_runState == RunState::Pending) {
     updateBootCountdown();
     return;  // app not loaded yet; skip the tick path
   }
 
-  if (!_lua) return;
-
-  // Standalone path always ticks; networked path gates on isConnected
-  // (matches today's Device::loop behavior).
-  bool shouldTick = !_courier.has_value() || isConnected();
-  if (!shouldTick) return;
-
-  // Drive every registered extension's update() at full main-loop rate
-  // — independent of whether an app is loaded. Drivers like button
-  // pollers depend on continuous polling for debounce and latency.
-  for (uint8_t i = 0; i < _config.extensions.count; i++) {
-    _config.extensions.items[i]->update();
-  }
-
-  // Lua tick + event dispatch only when an app is running and not suspended.
   if (_runState != RunState::Running) return;
+
+  // Networked apps tick only once connected (unchanged); standalone always.
+  if (_courier.has_value() && !isConnected()) return;
 
   unsigned long now = millis();
   unsigned long elapsed = now - _lastTickTime;

--- a/src/ResidentSandbox.h
+++ b/src/ResidentSandbox.h
@@ -183,6 +183,15 @@ private:
     // Track whether the Lua state has been initialised, so setup() is idempotent.
     bool _initialized = false;
 
+    // Unified lifecycle set: extensions[] plus any role-slot object not
+    // already present, de-duped by pointer. Driven for begin() and update().
+    Extension* _lifecycle[Extensions::MAX + 3] = {};
+    uint8_t _lifecycleCount = 0;
+    void buildLifecycleSet();
+    void addLifecycle(Extension* e);
+    // True iff e is one of the assigned role-slot objects (a peripheral).
+    bool isPeripheral(Extension* e) const;
+
     // Telemetry
     TelemetryCallback _telemetryCb;
     String _generationId;

--- a/src/ResidentSandbox.h
+++ b/src/ResidentSandbox.h
@@ -222,6 +222,10 @@ private:
     static constexpr unsigned long BOOT_COUNTDOWN_MS = 20000;
     void updateBootCountdown();
     void finishBootCountdown();
+    // Present the idle UI once the device is reachable (first connection, or
+    // standalone setup): identity screen + countdown if an app is persisted,
+    // else just the identity screen. No-op once an app is loaded/counting down.
+    void enterIdleScreen();
 
     // SystemButton gesture tracking during the countdown (Pending): a tap
     // loads the saved app, a long press forgets it. pressed() is a level read,

--- a/src/ResidentStatusDisplay.h
+++ b/src/ResidentStatusDisplay.h
@@ -2,14 +2,16 @@
 #ifndef RESIDENT_STATUS_DISPLAY_H
 #define RESIDENT_STATUS_DISPLAY_H
 
+#include "ResidentDriver.h"
+
 namespace Resident {
 
-class StatusDisplay {
+// A status display is a Driver that renders lines of status text. Lifecycle
+// (begin/update) comes from Extension; a device assigns one via
+// SandboxConfig::statusDisplay.
+class StatusDisplay : public Driver {
 public:
-  virtual void begin() {}                         // Device calls once at setup
-  virtual void update() {}                        // Device calls every loop
   virtual void displayText(const char* text) = 0;
-  virtual ~StatusDisplay() = default;
 };
 
 } // namespace Resident

--- a/src/ResidentStatusLED.h
+++ b/src/ResidentStatusLED.h
@@ -3,13 +3,13 @@
 #define RESIDENT_STATUS_LED_H
 
 #include <cstdint>
+#include "ResidentDriver.h"
 
 namespace Resident {
 
-class StatusLED {
+class StatusLED : public Driver {
 public:
   virtual void solidColor(uint32_t color) = 0;
-  virtual ~StatusLED() = default;
 };
 
 } // namespace Resident

--- a/src/ResidentSystemButton.h
+++ b/src/ResidentSystemButton.h
@@ -2,6 +2,8 @@
 #ifndef RESIDENT_SYSTEM_BUTTON_H
 #define RESIDENT_SYSTEM_BUTTON_H
 
+#include "ResidentDriver.h"
+
 namespace Resident {
 
 // A single hardware button read directly by the runtime — distinct from the
@@ -13,10 +15,9 @@ namespace Resident {
 // press + release) loads the saved app immediately, and a long press forgets
 // it. A natural home for future core button uses (e.g. hold-to-enter WiFi
 // config).
-class SystemButton {
+class SystemButton : public Driver {
 public:
   virtual bool pressed() = 0;
-  virtual ~SystemButton() = default;
 };
 
 } // namespace Resident

--- a/test/unit/test/test_sandbox_config/test_sandbox_config.cpp
+++ b/test/unit/test/test_sandbox_config/test_sandbox_config.cpp
@@ -1,4 +1,5 @@
 #include <unity.h>
+#include <type_traits>
 #include "ResidentSandboxConfig.h"
 #include "ResidentExtension.h"
 
@@ -9,10 +10,12 @@ public:
 };
 class StubStatusDisplay : public Resident::StatusDisplay {
 public:
+  const char* name() const override { return "stub-display"; }
   void displayText(const char* text) override { (void)text; }
 };
 class StubStatusLED : public Resident::StatusLED {
 public:
+  const char* name() const override { return "stub-led"; }
   void solidColor(uint32_t rgb) override { (void)rgb; }
 };
 }
@@ -69,11 +72,20 @@ void test_persistence_config_defaults(void) {
   TEST_ASSERT_NULL(cfg.persistentStore);              // default store selected by Sandbox
 }
 
+void test_roles_are_drivers(void) {
+  // The role interfaces must be Drivers (hence Extensions) so lifecycle is
+  // unified and a role pointer is an Extension pointer.
+  TEST_ASSERT_TRUE((std::is_base_of<Resident::Driver, Resident::StatusDisplay>::value));
+  TEST_ASSERT_TRUE((std::is_base_of<Resident::Driver, Resident::SystemButton>::value));
+  TEST_ASSERT_TRUE((std::is_base_of<Resident::Driver, Resident::StatusLED>::value));
+}
+
 int main(int, char**) {
     UNITY_BEGIN();
     RUN_TEST(test_default_construction);
     RUN_TEST(test_assign_top_level_fields);
     RUN_TEST(test_network_optional_can_be_assigned);
     RUN_TEST(test_persistence_config_defaults);
+    RUN_TEST(test_roles_are_drivers);
     return UNITY_END();
 }

--- a/test/unit/test/test_sandbox_lifecycle/test_sandbox_lifecycle.cpp
+++ b/test/unit/test/test_sandbox_lifecycle/test_sandbox_lifecycle.cpp
@@ -85,10 +85,46 @@ void test_begin_once_when_display_in_both_list_and_slot(void) {
   TEST_ASSERT_EQUAL_INT(1, display->beginCount);  // de-duped: begun once
 }
 
+void test_peripheral_updates_without_app_but_plain_driver_does_not(void) {
+  Resident::SandboxConfig cfg;
+  cfg.deviceType = "native-test";
+  cfg.extensions = {button, driver};   // button is also the system button
+  cfg.systemButton = button;           // -> peripheral
+  sandbox = new Resident::Sandbox(cfg);
+  sandbox->setup();                     // no app loaded -> RunState::Ready
+
+  int b0 = button->updateCount, d0 = driver->updateCount;
+  sandbox->loop();
+  TEST_ASSERT_EQUAL_INT(b0 + 1, button->updateCount);   // peripheral: always
+  TEST_ASSERT_EQUAL_INT(d0,     driver->updateCount);    // plain driver: not yet
+
+  sandbox->loadApp(APP);                // app loaded -> Running
+  int b1 = button->updateCount, d1 = driver->updateCount;
+  sandbox->loop();
+  TEST_ASSERT_EQUAL_INT(b1 + 1, button->updateCount);   // still updates
+  TEST_ASSERT_EQUAL_INT(d1 + 1, driver->updateCount);    // now updates too
+}
+
+void test_dual_role_object_updates_once_per_loop(void) {
+  Resident::SandboxConfig cfg;
+  cfg.deviceType = "native-test";
+  cfg.extensions = {button};            // in the list...
+  cfg.systemButton = button;            // ...and the slot (peripheral)
+  sandbox = new Resident::Sandbox(cfg);
+  sandbox->setup();
+  sandbox->loadApp(APP);                // Running: both cadences would apply
+
+  int b0 = button->updateCount;
+  sandbox->loop();
+  TEST_ASSERT_EQUAL_INT(b0 + 1, button->updateCount);   // once, not twice
+}
+
 int main(int, char**) {
   UNITY_BEGIN();
   RUN_TEST(test_begin_once_when_in_both_list_and_slot);
   RUN_TEST(test_begin_once_when_display_in_both_list_and_slot);
+  RUN_TEST(test_peripheral_updates_without_app_but_plain_driver_does_not);
+  RUN_TEST(test_dual_role_object_updates_once_per_loop);
   UNITY_END();
   return 0;
 }

--- a/test/unit/test/test_sandbox_lifecycle/test_sandbox_lifecycle.cpp
+++ b/test/unit/test/test_sandbox_lifecycle/test_sandbox_lifecycle.cpp
@@ -133,6 +133,42 @@ public:
   }
 };
 
+// A StatusDisplay assigned to cfg.statusDisplay ONLY (not in extensions[]) must
+// be begun and updated (lifecycle set covers it) but must NOT receive a Lua
+// global under its name(). luaGlobalBoolForTest("spy-display") reads nil (false)
+// for an unregistered name; a registered empty table reads true.
+void test_slot_only_display_no_lua_global(void) {
+  Resident::SandboxConfig cfg;
+  cfg.deviceType = "native-test";
+  // display is NOT in cfg.extensions — slot only
+  cfg.statusDisplay = display;
+  sandbox = new Resident::Sandbox(cfg);
+  sandbox->setup();
+
+  // Begun via lifecycle set
+  TEST_ASSERT_EQUAL_INT(1, display->beginCount);
+
+  // No Lua global registered for slot-only peripheral
+  TEST_ASSERT_FALSE(sandbox->luaGlobalBoolForTest("spy-display"));
+
+  // Updated on every loop (peripheral cadence)
+  int u0 = display->updateCount;
+  sandbox->loop();
+  TEST_ASSERT_EQUAL_INT(u0 + 1, display->updateCount);
+}
+
+// Counterpart: a driver in extensions[] DOES get a Lua global.
+void test_extension_driver_has_lua_global(void) {
+  Resident::SandboxConfig cfg;
+  cfg.deviceType = "native-test";
+  cfg.extensions = {driver};
+  sandbox = new Resident::Sandbox(cfg);
+  sandbox->setup();
+
+  // driver ("spy-driver") is in extensions[] -> its Lua global is registered
+  TEST_ASSERT_TRUE(sandbox->luaGlobalBoolForTest("spy-driver"));
+}
+
 void test_driver_event_dropped_until_app_loaded(void) {
   EventSpy* spy = new EventSpy();
   Resident::SandboxConfig cfg;
@@ -161,6 +197,8 @@ int main(int, char**) {
   RUN_TEST(test_begin_once_when_display_in_both_list_and_slot);
   RUN_TEST(test_peripheral_updates_without_app_but_plain_driver_does_not);
   RUN_TEST(test_dual_role_object_updates_once_per_loop);
+  RUN_TEST(test_slot_only_display_no_lua_global);
+  RUN_TEST(test_extension_driver_has_lua_global);
   RUN_TEST(test_driver_event_dropped_until_app_loaded);
   UNITY_END();
   return 0;

--- a/test/unit/test/test_sandbox_lifecycle/test_sandbox_lifecycle.cpp
+++ b/test/unit/test/test_sandbox_lifecycle/test_sandbox_lifecycle.cpp
@@ -27,8 +27,20 @@ public:
   void update() override { updateCount++; }
 };
 
+// A StatusDisplay spy usable as the statusDisplay slot and/or an extension.
+// Counts begin()/update(); displayText() is a no-op.
+class SpyDisplay : public Resident::StatusDisplay {
+public:
+  int beginCount = 0, updateCount = 0;
+  const char* name() const override { return "spy-display"; }
+  void begin() override { beginCount++; }
+  void update() override { updateCount++; }
+  void displayText(const char*) override {}
+};
+
 SpyButton* button = nullptr;
 SpyDriver* driver = nullptr;
+SpyDisplay* display = nullptr;
 Resident::Sandbox* sandbox = nullptr;
 
 constexpr const char* APP =
@@ -41,12 +53,14 @@ void setUp(void) {
   testMillis() = 0;
   button = new SpyButton();
   driver = new SpyDriver();
+  display = new SpyDisplay();
   sandbox = nullptr;
 }
 void tearDown(void) {
   delete sandbox; sandbox = nullptr;
   delete button; button = nullptr;
   delete driver; driver = nullptr;
+  delete display; display = nullptr;
 }
 
 void test_begin_once_when_in_both_list_and_slot(void) {
@@ -59,9 +73,22 @@ void test_begin_once_when_in_both_list_and_slot(void) {
   TEST_ASSERT_EQUAL_INT(1, button->beginCount);   // de-duped: begun once
 }
 
+// Guard against re-introducing the direct statusDisplay->begin() call that
+// existed before Task 2. If that call is re-added, beginCount becomes 2.
+void test_begin_once_when_display_in_both_list_and_slot(void) {
+  Resident::SandboxConfig cfg;
+  cfg.deviceType = "native-test";
+  cfg.extensions = {display};         // display in the extension list...
+  cfg.statusDisplay = display;        // ...and assigned as the status display
+  sandbox = new Resident::Sandbox(cfg);
+  sandbox->setup();
+  TEST_ASSERT_EQUAL_INT(1, display->beginCount);  // de-duped: begun once
+}
+
 int main(int, char**) {
   UNITY_BEGIN();
   RUN_TEST(test_begin_once_when_in_both_list_and_slot);
+  RUN_TEST(test_begin_once_when_display_in_both_list_and_slot);
   UNITY_END();
   return 0;
 }

--- a/test/unit/test/test_sandbox_lifecycle/test_sandbox_lifecycle.cpp
+++ b/test/unit/test/test_sandbox_lifecycle/test_sandbox_lifecycle.cpp
@@ -119,12 +119,49 @@ void test_dual_role_object_updates_once_per_loop(void) {
   TEST_ASSERT_EQUAL_INT(b0 + 1, button->updateCount);   // once, not twice
 }
 
+class EventSpy : public Resident::Driver {
+public:
+  int fired = 0;
+  const char* name() const override { return "probe"; }
+  void registerModule(Resident::LuaModule& m) override {
+    m.method<EventSpy, &EventSpy::luaFired>("fired");
+  }
+  int luaFired(lua_State*) { fired++; return 0; }
+  void emit() {
+    Resident::EventField f[] = {{"v", Resident::EventField::INT, {.i = 1}}};
+    sendEvent("ping", f, 1);
+  }
+};
+
+void test_driver_event_dropped_until_app_loaded(void) {
+  EventSpy* spy = new EventSpy();
+  Resident::SandboxConfig cfg;
+  cfg.deviceType = "native-test";
+  cfg.extensions = {spy};
+  sandbox = new Resident::Sandbox(cfg);
+  sandbox->setup();                       // Ready, no app
+
+  spy->emit();                            // event while no app is loaded
+  const char* APP_EV =
+      "function on_tick(ctx, dt) end\n"
+      "function on_event(ctx, e) probe.fired() end\n";
+  sandbox->loadApp(APP_EV);               // now Running
+  testMillis() += 200; sandbox->loop();   // dispatch a queued event, if any
+  TEST_ASSERT_EQUAL_INT(0, spy->fired);   // the Ready-time event was dropped
+
+  spy->emit();                            // event while Running
+  testMillis() += 200; sandbox->loop();
+  TEST_ASSERT_EQUAL_INT(1, spy->fired);   // delivered
+  delete spy;
+}
+
 int main(int, char**) {
   UNITY_BEGIN();
   RUN_TEST(test_begin_once_when_in_both_list_and_slot);
   RUN_TEST(test_begin_once_when_display_in_both_list_and_slot);
   RUN_TEST(test_peripheral_updates_without_app_but_plain_driver_does_not);
   RUN_TEST(test_dual_role_object_updates_once_per_loop);
+  RUN_TEST(test_driver_event_dropped_until_app_loaded);
   UNITY_END();
   return 0;
 }

--- a/test/unit/test/test_sandbox_lifecycle/test_sandbox_lifecycle.cpp
+++ b/test/unit/test/test_sandbox_lifecycle/test_sandbox_lifecycle.cpp
@@ -1,0 +1,67 @@
+// Lifecycle + update-cadence + event-gating tests for the unified peripheral
+// model. Networkless; spies count begin()/update() and dispatched events.
+#include <unity.h>
+#include <vector>
+#include "ResidentSandbox.cpp"
+
+namespace {
+
+// A SystemButton spy usable as the systemButton slot (a peripheral) and/or an
+// extension. Counts begin()/update(); pressed() returns a settable level.
+class SpyButton : public Resident::SystemButton {
+public:
+  int beginCount = 0, updateCount = 0;
+  bool down = false;
+  const char* name() const override { return "spy-button"; }
+  void begin() override { beginCount++; }
+  void update() override { updateCount++; }
+  bool pressed() override { return down; }
+};
+
+// A plain Driver spy (a non-peripheral extension). Counts begin()/update().
+class SpyDriver : public Resident::Driver {
+public:
+  int beginCount = 0, updateCount = 0;
+  const char* name() const override { return "spy-driver"; }
+  void begin() override { beginCount++; }
+  void update() override { updateCount++; }
+};
+
+SpyButton* button = nullptr;
+SpyDriver* driver = nullptr;
+Resident::Sandbox* sandbox = nullptr;
+
+constexpr const char* APP =
+    "function init(ctx) end\n"
+    "function on_tick(ctx, dt) end\n";
+
+}  // namespace
+
+void setUp(void) {
+  testMillis() = 0;
+  button = new SpyButton();
+  driver = new SpyDriver();
+  sandbox = nullptr;
+}
+void tearDown(void) {
+  delete sandbox; sandbox = nullptr;
+  delete button; button = nullptr;
+  delete driver; driver = nullptr;
+}
+
+void test_begin_once_when_in_both_list_and_slot(void) {
+  Resident::SandboxConfig cfg;
+  cfg.deviceType = "native-test";
+  cfg.extensions = {button};          // button in the extension list...
+  cfg.systemButton = button;          // ...and assigned as the system button
+  sandbox = new Resident::Sandbox(cfg);
+  sandbox->setup();
+  TEST_ASSERT_EQUAL_INT(1, button->beginCount);   // de-duped: begun once
+}
+
+int main(int, char**) {
+  UNITY_BEGIN();
+  RUN_TEST(test_begin_once_when_in_both_list_and_slot);
+  UNITY_END();
+  return 0;
+}

--- a/test/unit/test/test_sandbox_persistence/test_sandbox_persistence.cpp
+++ b/test/unit/test/test_sandbox_persistence/test_sandbox_persistence.cpp
@@ -33,6 +33,7 @@ public:
 
 class SpyDisplay : public Resident::StatusDisplay {
 public:
+  const char* name() const override { return "spy-display"; }
   std::vector<std::string> texts;
   void displayText(const char* text) override { texts.push_back(text ? text : ""); }
   std::string last() const { return texts.empty() ? "" : texts.back(); }
@@ -40,6 +41,7 @@ public:
 
 class SpyButton : public Resident::SystemButton {
 public:
+  const char* name() const override { return "spy-button"; }
   bool down = false;
   bool pressed() override { return down; }
 };

--- a/test/unit/test/test_sandbox_persistence/test_sandbox_persistence.cpp
+++ b/test/unit/test/test_sandbox_persistence/test_sandbox_persistence.cpp
@@ -304,6 +304,29 @@ void test_suspend_during_countdown_is_ignored(void) {
   TEST_ASSERT_TRUE(telemetryHas("app_restored"));
 }
 
+// Networked: the identity screen + countdown are armed on first connection, not
+// at setup. The stub Courier never reaches Connected, so the persisted app is
+// loaded into the pending buffer but the countdown is NOT armed and nothing is
+// painted — the device waits on the connection screen. (Standalone arms at
+// setup; see test_countdown_shows_deviceid_and_counts_down.)
+void test_networked_countdown_armed_on_connect_not_setup(void) {
+  store->save(GOOD_APP, strlen(GOOD_APP));
+  Resident::SandboxConfig cfg;
+  cfg.deviceType    = "native-test";
+  cfg.statusDisplay = display;
+  cfg.persistApps   = true;
+  cfg.persistentStore = store;
+  Courier::Config courier;
+  cfg.network = courier;                 // networked — stub never connects
+  sandbox = new Resident::Sandbox(cfg);
+  sandbox->setup();
+
+  sandbox->loop();
+  sandbox->loop();
+  TEST_ASSERT_FALSE(sandbox->isAppRunning());            // not loaded at setup
+  TEST_ASSERT_EQUAL_INT(0, (int)display->texts.size());  // no countdown until connected
+}
+
 int main(int, char**) {
   UNITY_BEGIN();
   RUN_TEST(test_save_after_successful_load);
@@ -323,6 +346,7 @@ int main(int, char**) {
   RUN_TEST(test_clear_persisted_app);
   RUN_TEST(test_persist_no_display_skips_countdown);
   RUN_TEST(test_suspend_during_countdown_is_ignored);
+  RUN_TEST(test_networked_countdown_armed_on_connect_not_setup);
   UNITY_END();
   return 0;
 }


### PR DESCRIPTION
## Unified driver lifecycle & update cadence

Rationalises how Resident drives peripherals and sandbox drivers. Previously the device-role peripherals (status display, system button, status LED) were managed on a separate, inconsistent path from `extensions[]`, and driver `update()` was gated on connectivity and skipped during the boot countdown — so a paused app kept drivers alive but a brief WiFi drop or the countdown killed their heartbeat.

### What changed

- **Roles are now `Driver` subclasses** (`StatusDisplay`/`SystemButton`/`StatusLED : public Driver`). Concrete drivers collapse to single inheritance, so a role pointer *is* an `Extension*` at the same address — making identity trivial (no diamond, no virtual inheritance, no RTTI). Capability lives on the driver; the role is *assigned* by the config slot, so drivers stay reusable across boards.
- **One de-duplicated lifecycle list** (`extensions[]` ∪ role slots). `begin()` runs once per object at setup (kills the old double-begin and the hand-rolled `_initialized` guards). Lua modules register only for declared `extensions[]`.
- **Two `update()` cadences**: role peripherals update **every loop, always**; other extensions update **only while an app is loaded** (Running/Suspended). **Connectivity gates neither** — the mic (and any driver) keeps being serviced across a reconnect. The Lua `on_tick` keeps its Running + connected gate, unchanged.
- **Driver events** are dropped unless an app is loaded (Ready/Pending → dropped; Suspended still defers and dispatches on resume).
- **`PushButtonsDriver::pressed()`** simplifies to the driver's debounced `isDown` (the direct-pin-read workaround is deleted), now that the button heartbeat runs during the countdown. The release edge is now debounced too.

### Why

A driver may need continuous servicing independent of WiFi and app state — e.g. a mic opened by the sandbox detecting silence across a reconnect, or m5stick-voice's long-press exo-sandbox mic while the app is suspended. This makes the driver heartbeat continuous and the device-role peripherals first-class.

### Testing

- New `test_sandbox_lifecycle` suite: begin-once (de-dup), the two cadences, dual-role-updates-once, event-drop-unless-app-loaded, slot-only-peripheral-registers-no-global.
- Full native suite **54/54**; `test_sandbox_suspend`/`test_sandbox_persistence` stay green (regression guards).
- `./tools/run-tests.py build` green (4 PlatformIO envs) and static-analysis green. Pure ESP-IDF `espidf-basic` builds clean locally.

### Pre-merge / on-device

One driver behaviour isn't native-unit-testable (the example `PushButtonsDriver` isn't in the harness): on a device, confirm hold-to-delete completes a long-press without being aborted by contact chatter, and a rapid tap still registers. Out of scope here: migrating the separate **hawthorn-firmware** drivers (each multi-inheriting a role interface drops to single inheritance + must implement `name()`) — a follow-up in that repo.

Built via spec → plan → subagent-driven TDD (6 tasks), each with a per-task spec+quality review plus an opus whole-branch review; all findings fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
