### PR TITLE
feat(sandbox): idle-screen title + repaint after persisted-app restore

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,11 @@
   state and during the Pending boot countdown — above `Device ID` / `Type`.
   Internal: `showIdentityScreen` renamed to `showIdleScreen`.
 
+- **Idle screen repainted after a persisted-app restore.** `finishBootCountdown`
+  now repaints the resting idle screen after the countdown loads the app, so
+  devices with a status display separate from the app screen no longer get stuck
+  on the last countdown frame (no-op where the app owns the screen).
+
 - **Boot identity screen now waits for connectivity.** A networked device shows
   its connection status while connecting, then — once **connected** — the
   identity screen and (if an app is persisted) the 20-second countdown. A

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,6 +26,11 @@
   implementation must now also implement `Driver::name()` (a pure virtual
   returning a `const char*` identifier).
 
+- **Idle-screen title.** `Sandbox::setIdleScreenTitle(const char*)` adds an
+  optional line at the top of the idle screen — shown in both the resting Ready
+  state and during the Pending boot countdown — above `Device ID` / `Type`.
+  Internal: `showIdentityScreen` renamed to `showIdleScreen`.
+
 - **Boot identity screen now waits for connectivity.** A networked device shows
   its connection status while connecting, then — once **connected** — the
   identity screen and (if an app is persisted) the 20-second countdown. A

--- a/src/ResidentSandbox.cpp
+++ b/src/ResidentSandbox.cpp
@@ -458,18 +458,15 @@ void Sandbox::showStatusText(const char* text)
   _config.statusDisplay->displayText(text);
 }
 
-void Sandbox::showIdentityScreen(int countdownSecs)
+void Sandbox::showIdleScreen(int countdownSecs)
 {
   if (!_config.statusDisplay) return;
-  char buf[96];
-  if (countdownSecs >= 0) {
-    snprintf(buf, sizeof(buf), "Device ID: %s\nType: %s\n\n%ds",
-             _deviceId.c_str(), getDeviceType(), countdownSecs);
-  } else {
-    snprintf(buf, sizeof(buf), "Device ID: %s\nType: %s",
-             _deviceId.c_str(), getDeviceType());
-  }
-  showStatusText(buf);
+  String s;
+  if (_idleScreenTitle.length() > 0) { s += _idleScreenTitle; s += '\n'; }
+  s += "Device ID: "; s += _deviceId;
+  s += "\nType: ";     s += getDeviceType();
+  if (countdownSecs >= 0) { s += '\n'; s += String(countdownSecs); s += 's'; }
+  showStatusText(s.c_str());
 }
 
 void Sandbox::enterIdleScreen()
@@ -500,7 +497,7 @@ void Sandbox::showReadyScreen()
   // Show it once the device is reachable (connected, or standalone); while
   // connecting, the connection-status text shows instead, and while an app
   // runs it owns the screen.
-  if (!_courier.has_value() || isConnected()) showIdentityScreen();
+  if (!_courier.has_value() || isConnected()) showIdleScreen();
 }
 
 void Sandbox::loop() {
@@ -613,7 +610,7 @@ void Sandbox::updateBootCountdown()
   int remaining = (int)((BOOT_COUNTDOWN_MS - elapsed + 999) / 1000);
   if (remaining != _lastCountdownSecondShown) {
     _lastCountdownSecondShown = remaining;
-    showIdentityScreen(remaining);
+    showIdleScreen(remaining);
   }
 }
 

--- a/src/ResidentSandbox.cpp
+++ b/src/ResidentSandbox.cpp
@@ -664,6 +664,11 @@ void Sandbox::finishBootCountdown()
   bool ok = loadAppInternal(src.c_str(), /*persistOnSuccess=*/false);
   if (ok) {
     emitTelemetry("app_restored");
+    // Repaint the resting idle screen (clears the countdown). On devices whose
+    // status display IS the app screen this no-ops (the app owns it); on devices
+    // with a separate status display (e.g. a dedicated status LCD) it brings the
+    // idle screen back instead of leaving the last countdown frame stuck.
+    showReadyScreen();
     return;
   }
 

--- a/src/ResidentSandbox.h
+++ b/src/ResidentSandbox.h
@@ -177,8 +177,9 @@ private:
 
     // Status display helpers.
     void showStatusText(const char* text);
-    // Paint the device-identity screen: "Device ID: <id>\nType: <t>", plus a
-    // "\n\n<secs>s" line when countdownSecs >= 0 (the boot countdown).
+    // Paint the idle screen: an optional title line (setIdleScreenTitle) on top,
+    // then "Device ID: <id>\nType: <t>", plus a "\n<secs>s" line when
+    // countdownSecs >= 0 (the boot countdown).
     void showIdleScreen(int countdownSecs = -1);
     // Paint the Ready identity screen when the device is idle and reachable
     // (connected, or standalone). No-op while connecting or app-owned.

--- a/src/ResidentSandbox.h
+++ b/src/ResidentSandbox.h
@@ -28,6 +28,11 @@ public:
 
     void setTelemetryCallback(TelemetryCallback cb) { _telemetryCb = cb; }
 
+    // Optional line shown at the TOP of the idle screen (Ready + Pending),
+    // above Device ID / Type. Empty by default. Device-supplied (e.g. a
+    // wake-word hint); resident never generates it.
+    void setIdleScreenTitle(const char* title) { _idleScreenTitle = title ? title : ""; }
+
     // Current generation ID (from last app/shader message)
     const String& generationId() const { return _generationId; }
 
@@ -174,7 +179,7 @@ private:
     void showStatusText(const char* text);
     // Paint the device-identity screen: "Device ID: <id>\nType: <t>", plus a
     // "\n\n<secs>s" line when countdownSecs >= 0 (the boot countdown).
-    void showIdentityScreen(int countdownSecs = -1);
+    void showIdleScreen(int countdownSecs = -1);
     // Paint the Ready identity screen when the device is idle and reachable
     // (connected, or standalone). No-op while connecting or app-owned.
     void showReadyScreen();
@@ -212,6 +217,8 @@ private:
     PersistentStore* _store = nullptr;
     bool _lastInitOk = false;   // set by compileApp via callInit()
     bool loadAppInternal(const char* luaCode, bool persistOnSuccess);
+
+    String _idleScreenTitle;   // optional top line on the idle screen (see setIdleScreenTitle)
 
     // Boot countdown data (active while _runState == RunState::Pending): show
     // the device ID for BOOT_COUNTDOWN_MS before auto-loading the persisted

--- a/test/unit/test/test_sandbox_persistence/test_sandbox_persistence.cpp
+++ b/test/unit/test/test_sandbox_persistence/test_sandbox_persistence.cpp
@@ -135,13 +135,13 @@ void test_countdown_shows_deviceid_and_counts_down(void) {
   makeSandbox(true, false);                  // setup() arms the countdown
 
   sandbox->loop();                            // t=0 -> "20s"
-  TEST_ASSERT_EQUAL_STRING("Device ID: a4cf1200\nType: native-test\n\n20s",
+  TEST_ASSERT_EQUAL_STRING("Device ID: a4cf1200\nType: native-test\n20s",
                            display->last().c_str());
   TEST_ASSERT_FALSE(sandbox->isAppRunning()); // not loaded during countdown
 
   testMillis() = 5000;                        // 15s remaining
   sandbox->loop();
-  TEST_ASSERT_EQUAL_STRING("Device ID: a4cf1200\nType: native-test\n\n15s",
+  TEST_ASSERT_EQUAL_STRING("Device ID: a4cf1200\nType: native-test\n15s",
                            display->last().c_str());
 }
 
@@ -156,6 +156,11 @@ void test_countdown_autoloads_after_20s(void) {
   sandbox->loop();
   TEST_ASSERT_TRUE(sandbox->isAppRunning());
   TEST_ASSERT_TRUE(telemetryHas("app_restored"));
+  // The idle screen is repainted after the restore (clears the countdown), so a
+  // separate status display returns to the identity screen instead of the last
+  // countdown frame.
+  TEST_ASSERT_EQUAL_STRING("Device ID: a4cf1200\nType: native-test",
+                           display->last().c_str());
 }
 
 void test_button_tap_loads_app_now(void) {


### PR DESCRIPTION
Idle-screen improvements developed and hardware-validated against the
hawthorn-firmware devices (m5sticks3, time-p1, lamp/fan). All changelog entries
are under the existing `v0.5.1-dev` section.

## Changes

- **`Sandbox::setIdleScreenTitle(const char*)`** — an optional line at the top of
  the idle screen (shown in both the resting Ready state and during the Pending
  boot countdown), above `Device ID` / `Type`. Devices use it for e.g. a
  wake-word hint, replacing fragile paint-on-connect overlays. The countdown line
  also drops to a single `\n` separator (was `\n\n`).
- **Internal rename** `showIdentityScreen` → `showIdleScreen` (private; it's used
  for both Ready and Pending).
- **Repaint the idle screen after a persisted-app restore** — `finishBootCountdown`
  now repaints the resting idle screen on a successful restore. On devices whose
  status display IS the app screen this no-ops (the app owns it); on devices with
  a *separate* status display (e.g. a dedicated status LCD) it returns to the idle
  screen instead of being stuck on the last countdown frame.
- Doc comment fix on the renamed helper.

## Tests

- Updated the persistence-countdown assertions to the single-newline format and
  added coverage that the idle screen repaints after a restore.
- `./tools/run-tests.py unit` → **55/55 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)