### PR TITLE
Release 0.6.0 — require Courier 0.5.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.6.0-dev
+## v0.6.0
 
 ### New features
 
@@ -75,6 +75,10 @@
 ### Fixes
 
 - **Lua allocator falls back to internal RAM on boards without PSRAM** (e.g. ESP32-S3FN8 / M5Dial). Previously every Lua allocation went to `MALLOC_CAP_SPIRAM`, which returns NULL when no PSRAM exists — the Lua runtime had no usable heap and every app failed with "not enough memory". The capability is now resolved once on first use: SPIRAM when present, internal 8-bit RAM otherwise. Boards with PSRAM are unaffected.
+
+### Dependencies
+
+- **Courier 0.5.0.** The ESP Component Registry manifests now require `^0.5.0`, which brings NTP-first time sync (with a hardened HTTPS-Date fallback) and larger receivable payloads on no-PSRAM boards — directly benefiting pushed app code. The PlatformIO manifest continues to track Courier's `main` via git URL until 0.5.0 lands on the PlatformIO registry (currently 0.4.2).
 
 ---
 

--- a/examples/espidf-basic/main/idf_component.yml
+++ b/examples/espidf-basic/main/idf_component.yml
@@ -12,9 +12,9 @@ dependencies:
   espressif/arduino-esp32:
     version: "^3.0.0"
 
-  # Courier 0.4.1+ for per-transport setEndpoint() + Client::reconnect().
+  # Courier 0.5.0+ (NTP-first time sync, per-transport setEndpoint()).
   inanimate/courier:
-    version: "^0.4.1"
+    version: "^0.5.0"
 
   bblanchon/arduinojson:
     version: "^7.0.0"

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.6.0-dev"
+version: "0.6.0"
 description: "Sandbox with hardware IO and hot reload for ESP32 devices"
 url: "https://github.com/inanimate-tech/resident"
 
@@ -7,11 +7,12 @@ dependencies:
     version: ">=5.0.0"
   espressif/arduino-esp32:
     version: "^3.0.0"
-  # Courier 0.4.1 adds per-transport endpoint state + Client::reconnect();
-  # Resident's Device sets the WS endpoint via _ws.setEndpoint() inside
-  # onTransportsWillConnect(), which requires that surface.
+  # Courier 0.5.0: NTP-first time sync (robust HTTPS-Date fallback), larger
+  # receivable payloads on no-PSRAM boards, and per-transport endpoint state
+  # (Resident sets the WS endpoint via _ws.setEndpoint() inside
+  # onTransportsWillConnect(), which requires that surface).
   inanimate/courier:
-    version: "^0.4.1"
+    version: "^0.5.0"
   bblanchon/arduinojson:
     version: "^7.0.0"
   # Esp32Lua is not on the ESP component registry. Consumers must provide it

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "resident",
-  "version": "0.6.0-dev",
+  "version": "0.6.0",
   "description": "Sandbox with hardware IO and hot reload for ESP32 devices",
   "keywords": "esp32, sandbox, iot, hot-reload",
   "repository": {


### PR DESCRIPTION
Bumps resident to **0.6.0** (drops the `-dev` suffix) so it can be published to the PlatformIO and ESP Component registries, and moves the Courier dependency to **0.5.0**.

## Changes
- **`idf_component.yml`** (library + `espidf-basic` example): Courier `^0.4.1` → `^0.5.0`. The ESP Component Registry has Courier 0.5.0 (NTP-first time sync + hardened HTTPS-Date fallback; larger receivable payloads on no-PSRAM boards).
- **`library.json`**: Courier dep intentionally **left as the git URL**. The PlatformIO registry currently maxes at Courier 0.4.2, so the git URL (tracking `main` = 0.5.0) remains the correct reference there until 0.5.0 is published to PlatformIO. This matches the already-published resident 0.5.0.
- **`docs/changelog.md`**: cut `v0.6.0`, added a Dependencies note.
- Version bumped in both `library.json` and `idf_component.yml` (they must match for preflight).

## Verification
- `./tools/publish-preflight.py` passes: local `0.6.0` > published `0.5.0` on both registries, versions match, no pre-release suffix.
- Resident was validated on hardware against Courier 0.5.0 this cycle (M5StickC S3 running `m5stick-voice`): WiFi + NTP time sync + WebSocket to the worker + app push all green.

## Publishing
After merge, pushing a `v0.6.0` tag triggers `.github/workflows/publish.yml` (preflight → publish to both registries in parallel). Publishing is permanent — versions can't be reused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)