### PR TITLE
Release 0.6.1 — pin Courier ^0.5.0 on both registries

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.6.1
+
+### Dependencies
+
+- **Courier `^0.5.0` on both registries.** Now that Courier 0.5.0 is published to the PlatformIO registry (previously only 0.4.2 was available there), `library.json` pins `inanimate/courier` to `^0.5.0` instead of tracking `main` via a git URL. Both the PlatformIO and ESP Component manifests now resolve Courier from their respective registries, so resident is fully version-pinned and safe to depend on from a registry.
+
+---
+
 ## v0.6.0
 
 ### New features

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.6.0"
+version: "0.6.1"
 description: "Sandbox with hardware IO and hot reload for ESP32 devices"
 url: "https://github.com/inanimate-tech/resident"
 

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "resident",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Sandbox with hardware IO and hot reload for ESP32 devices",
   "keywords": "esp32, sandbox, iot, hot-reload",
   "repository": {
@@ -17,7 +17,7 @@
   "frameworks": ["arduino", "espidf"],
   "platforms": "espressif32",
   "dependencies": {
-    "inanimate/courier": "https://github.com/inanimate-tech/courier.git",
+    "inanimate/courier": "^0.5.0",
     "bblanchon/ArduinoJson": "^7.4.2",
     "fischer-simon/Esp32Lua": "^5.4.7"
   },


### PR DESCRIPTION
Now that **Courier 0.5.0 is published to the PlatformIO registry** (it was only 0.4.2 there when 0.6.0 shipped), resident can pin Courier to `^0.5.0` on *both* registries instead of tracking `main` via a git URL in the PlatformIO manifest. This makes resident fully version-pinned and dependable from a registry.

## Changes
- **`library.json`**: `inanimate/courier` git URL → `^0.5.0`.
- **Version**: `0.6.0` → `0.6.1` in `library.json` + `idf_component.yml`.
- **`docs/changelog.md`**: new `v0.6.1` section (Dependencies).
- (`idf_component.yml` already required `^0.5.0` from the 0.6.0 release — unchanged.)

## Verification
- `./tools/publish-preflight.py` passes: `0.6.1` > published `0.6.0` on both registries, versions match, no `-dev`.
- `m5stick-demo` builds with `inanimate/courier @ ^0.5.0` resolved from the PlatformIO registry (`courier@0.5.0 has been installed!`), links and images cleanly (Flash 24.0%).
- Both registries confirmed serving Courier 0.5.0.

## Publishing
After merge, a `v0.6.1` tag triggers `.github/workflows/publish.yml` → publish to both registries. Permanent once published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)