### PR TITLE
Per-surface overlay claims + message interposition (v0.6.2-dev)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -162,6 +162,34 @@ sandbox.onConnected([]() {
 });
 ```
 
+### Message interposition
+
+Three tools for platform wrappers that need to sit in front of the sandbox's message routing without re-implementing it:
+
+```cpp
+// Pre-routing filter (single-slot). Runs before app-load deferral, reserved-
+// type routing (app/shader/app_event/forget), and the user onMessage
+// callback. Return true to continue routing; false to consume the message.
+sandbox.onMessageFilter([](const char* transport, const char* type, JsonDocument& doc) {
+    if (strcmp(type, "my_platform_thing") == 0) { handleIt(doc); return false; }
+    if (isDuplicate(doc["nonce"] | "")) return false;
+    return true;
+});
+
+// Defer app/shader loads during a memory/CPU-sensitive window (e.g. voice
+// recording — a Lua compile would stall the audio path). Stash is last-one-
+// wins; clearing applies it immediately. Other message types flow normally.
+sandbox.deferAppLoads(true);
+// ... later ...
+sandbox.deferAppLoads(false);          // applies any stashed app/shader now
+sandbox.hasDeferredAppLoad();          // pending stash?
+
+// Route a message through the pipeline (filter → deferral → routing → user
+// callback) as if it arrived from a transport — for wrappers with their own
+// receive path, and for native tests.
+sandbox.injectMessage("mqtt", "app", doc);
+```
+
 | Callback | Signature | Fires |
 |----------|-----------|-------|
 | `onTransportsWillConnect` | `void()` | Once, after Resident sets the default WS path and before transports start. Override the path here. |
@@ -182,9 +210,9 @@ sandbox.suspendApp();                  // pause the running app's tick without u
 sandbox.resumeApp();                   // resume a suspended app
 sandbox.isAppSuspended();              // true between suspendApp() and resumeApp()
 sandbox.onSystemButtonHold(cb);        // cb(true) on hold (past threshold), cb(false) on release
-sandbox.addOverlay(&ov, &surface);     // register an overlay bound to a display surface
-sandbox.requestOverlay(&ov, show);     // request show/hide; the arbiter draws the highest-priority one
-sandbox.removeOverlay(&ov);            // deregister (tears the overlay down, resumes app if it suspended)
+sandbox.addOverlay(&ov, &surface, prio); // register a claim on a display surface, with priority
+sandbox.requestOverlay(&ov, show);       // request show/hide; per-surface arbitration picks winners
+sandbox.removeOverlay(&ov);              // deregister (tears the overlay down, resumes app if it suspended)
 sandbox.startMicStream();              // stream systemMic frames (default sink: ws().sendBinary)
 sandbox.stopMicStream();               // stop streaming
 sandbox.isMicStreaming();              // true while streaming
@@ -375,7 +403,9 @@ runs on a single de-duplicated list every loop:
 
 A driver fills a device role by implementing the role interface (`SystemDisplay`
 / `SystemButton` / `SystemLED` / `SystemMic`, each a `Driver` subclass) — that's the
-*capability*. Whether it's *used* in that role is the per-device config slot,
+*capability*. `SystemDisplay` additionally has an optional `restoreContent()`
+(default no-op): repaint the surface's underlying content after the last
+[Overlay](#residentoverlay) claiming it releases. Whether it's *used* in that role is the per-device config slot,
 so the same driver is reusable across boards. An object fills at most one role.
 (`StatusDisplay` / `StatusLED` remain as deprecated aliases for `SystemDisplay`
 / `SystemLED`.)
@@ -543,34 +573,35 @@ While streaming, each `Sandbox::loop()` reads up to `frameSamples()` (capped at 
 
 ## Resident::Overlay
 
-An overlay temporarily takes over a display to show transient UI (a "Listening" prompt, a recording animation) on top of — or instead of — the running app.
+An overlay is a transient **claim on a display surface** — a "Listening" prompt, a recording animation — shown on top of, or instead of, whatever the surface normally displays.
 
 ```cpp
 class ListeningOverlay : public Resident::Overlay {
 public:
-    int  priority() const override { return 100; }   // higher wins arbitration
-    void onDraw() override { display.displayText("Listening"); }
-    // onActivate() / onDeactivate() / restore() are optional (default no-op)
+    void onAcquire() override { display.displayText("Listening"); }
+    // onDraw(dt) / onRelease() are optional too (default no-op)
 };
 ```
 
 | Method | Default | Description |
 |--------|---------|-------------|
-| `priority()` | *(pure virtual)* | Higher-priority overlays win when several are requested at once |
-| `onActivate()` | no-op | Called when this overlay becomes the winner |
-| `onDraw()` | no-op | Called every `loop()` while this overlay is the winner |
-| `onDeactivate()` | no-op | Called when this overlay stops being the winner |
-| `restore()` | no-op | Repaint the app's last frame — called on resume after a surface-sharing overlay hides |
+| `onAcquire()` | no-op | You now own the surface; paint the first frame here for immediate response |
+| `onDraw(dtMs)` | no-op | Animation heartbeat while owning, paced on the app-tick cadence (~10 FPS) — the overlay takes over the suspended app's tick slot. Event-driven repaints outside `onDraw` are fine too |
+| `onRelease()` | no-op | You no longer own the surface — wind down internal state only; the arbiter handles app resume and surface restore |
 
 Register and drive overlays from the Sandbox:
 
 ```cpp
-sandbox.addOverlay(&overlay, &systemDisplay);  // bind to the display it draws on
-sandbox.requestOverlay(&overlay, true);        // request show; false to hide
-sandbox.removeOverlay(&overlay);               // deregister
+sandbox.addOverlay(&overlay, &systemDisplay, 100);  // claim on a surface, with priority
+sandbox.requestOverlay(&overlay, true);             // request show; false to hide
+sandbox.removeOverlay(&overlay);                    // deregister
 ```
 
-Each `loop()` the arbiter draws the highest-`priority()` *requested* overlay. **App suspension is derived, not declared:** the app is suspended while the winning overlay's bound surface is *dual-role* — the same display is both an app-facing extension (in `cfg.extensions[]`) **and** a `system*` role slot. On such a shared surface the app must be stopped from drawing over the overlay, so the arbiter calls `suspendApp()` while it shows and `resumeApp()` + the overlay's `restore()` when it hides. If the overlay draws on a **dedicated** system display (role-only, not the app's screen), the app is never suspended — it keeps running on its own screen. The arbiter only resumes an app it suspended itself.
+**Arbitration is per surface.** Overlays bound to the same surface contend by priority (highest wins; ties go to the earlier registration); overlays on different surfaces are independent and can all show at once. A `nullptr` surface means a **dedicated surface**: the overlay contends with nothing, never suspends the app, and no restore is issued for it — right for a display that exists only to show this overlay.
+
+**App suspension is derived, not declared:** the app is suspended while any winning claim's surface is *dual-role* — the same display is both an app-facing extension (in `cfg.extensions[]`) **and** a `system*` role slot. On such a shared surface the app must be stopped from drawing over the overlay, so the arbiter calls `suspendApp()` while the claim is held and `resumeApp()` when it ends. An app pushed while a dual-role claim is held loads suspended rather than ticking beneath the overlay. The arbiter only resumes an app it suspended itself — a device-initiated `suspendApp()` survives overlay churn.
+
+**Surface restore belongs to the surface.** When a surface's last claim releases, the arbiter calls `SystemDisplay::restoreContent()` on it — repaint the underlying content (last app frame, idle screen, prior status text) there. Overlays never restore; a handoff to another overlay on the same surface issues no restore.
 
 Core ships the overlay *mechanism* and no concrete overlays; the running app is not overlaid by any of Resident's own status screens (those show only when no app owns the display).
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -179,6 +179,8 @@ sandbox.onMessageFilter([](const char* transport, const char* type, JsonDocument
 // Defer app/shader loads during a memory/CPU-sensitive window (e.g. voice
 // recording — a Lua compile would stall the audio path). Stash is last-one-
 // wins; clearing applies it immediately. Other message types flow normally.
+// The applied stash routes straight to loading — the filter already ran at
+// receipt, so a dedup filter like the one above won't drop it a second time.
 sandbox.deferAppLoads(true);
 // ... later ...
 sandbox.deferAppLoads(false);          // applies any stashed app/shader now

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.6.2-dev
+## v0.6.2-dev (0dcfd11)
 
 ### Breaking changes
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## v0.6.2-dev (0dcfd11)
+## v0.6.2
+
+### Dependencies
+
+- **Courier `^0.5.1` on both registries** (was `^0.5.0`). 0.5.1 enables the
+  IDF certificate bundle by default on the WS and MQTT transports; the surface
+  Resident itself relies on is unchanged since 0.5.0.
 
 ### Breaking changes
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,67 @@
 # Changelog
 
+## v0.6.2-dev
+
+### Breaking changes
+
+- **Overlay arbitration is now per surface, and the Overlay interface is
+  reshaped.** Driven by the first multi-overlay consumer (Hawthorn devices
+  with a voice overlay and an agent-status overlay, sometimes on different
+  screens):
+  - **Per-surface winners.** Overlays bound to the same surface contend by
+    priority (ties: earlier registration); overlays on different surfaces are
+    independent and can all show at once. Previously one global winner was
+    drawn regardless of surface. A `nullptr` surface is now defined: a
+    dedicated surface — contends with nothing, never suspends the app, no
+    restore issued.
+  - **`priority()` is no longer a virtual** — pass it to
+    `addOverlay(overlay, surface, priority)` instead.
+  - **`onActivate()` / `onDeactivate()` → `onAcquire()` / `onRelease()`** —
+    an overlay is a *claim* on a surface; the names now say so.
+  - **`Overlay::restore()` is gone; surfaces restore themselves.** New
+    `SystemDisplay::restoreContent()` (default no-op) is called by the
+    arbiter when a surface's last claim releases — uniformly, whether or not
+    the app was suspended (previously restore only fired on the app-resume
+    path, so non-suspending surfaces never restored). A handoff to another
+    overlay on the same surface issues no restore.
+  - **`onDraw(unsigned long dtMs)` is paced on the app-tick cadence**
+    (10 FPS) instead of every `loop()` — the overlay takes over the
+    suspended app's tick slot, and consumers no longer need hand-rolled
+    draw throttling. `onAcquire` is the immediate first paint.
+
+### New features
+
+- **`Sandbox::onMessageFilter(cb)`** — single-slot pre-routing filter. Runs
+  before app-load deferral, reserved-type routing (`app`/`shader`/
+  `app_event`/`forget`), and the user `onMessage` callback; return `false`
+  to consume the message. Platform wrappers (e.g. Hawthorn's
+  HawthornRoomDevice) use this for dedup, self-echo filtering, and
+  platform-only message types — previously they had to overwrite the
+  sandbox's Courier `onMessage` hook and re-implement reserved-type routing
+  by hand, which silently drifted as routing grew (the wrapper's copy
+  predated `forget`, so `forget` was dead on those devices).
+- **`Sandbox::deferAppLoads(bool)`** — while set, incoming `app`/`shader`
+  messages are stashed (last one wins, heap-serialized at measured size)
+  instead of loaded; clearing applies the stashed load immediately. For
+  memory/CPU-sensitive windows like voice recording, where a Lua compile
+  would stall the audio path. `hasDeferredAppLoad()` reports a pending
+  stash.
+- **`Sandbox::injectMessage(transportName, type, doc)`** — route a message
+  through the sandbox exactly as if it arrived from a transport (filter →
+  deferral → reserved-type routing → user callback). For wrappers with
+  their own receive path, and for native tests.
+
+### Fixes
+
+- **An app pushed while a dual-role overlay claim is held now loads
+  suspended** instead of ticking (and drawing) beneath the overlay, and the
+  arbiter's suspension bookkeeping is reset when the previous app is stopped
+  (previously a stale flag could leave the new app un-suspended).
+- **A device-initiated `suspendApp()` now survives an overlay cycle**: the
+  arbiter only resumes a suspension it performed itself.
+
+---
+
 ## v0.6.1
 
 ### Dependencies

--- a/examples/m5stick-voice/README.md
+++ b/examples/m5stick-voice/README.md
@@ -66,11 +66,11 @@ Push-to-talk is built entirely on Resident's core primitives, wired up in
 - **Hold detection** — `PushButtonsDriver` doubles as the `SystemButton` role;
   the sandbox derives the hold/release gesture from it and calls back with
   `held`.
-- **"Listening" overlay** — while held, `requestOverlay` activates a small
-  `Overlay` that draws "Listening" over the dual-role display. Because the
-  display is dual-role, activating the overlay suspends the app (there is no
-  app here, so this just takes over the idle screen) and repaints the idle
-  prompt on release.
+- **"Listening" overlay** — while held, `requestOverlay` raises a claim on
+  the dual-role display and the overlay paints "Listening" in `onAcquire`.
+  Because the display is dual-role, the claim suspends the app (there is no
+  app here, so this just takes over the idle screen). On release the arbiter
+  calls the display's `restoreContent()`, which repaints the idle prompt.
 - **Mic streaming pump** — `startMicStream()` / `stopMicStream()` drive the
   sandbox's built-in pump, which drains `SystemMic` each `loop()` and ships
   16 kHz int16 PCM frames straight to the WebSocket.

--- a/examples/m5stick-voice/device/src/main.cpp
+++ b/examples/m5stick-voice/device/src/main.cpp
@@ -25,31 +25,33 @@ static constexpr uint8_t BUTTON_PINS[] = {37, 39};
 #endif
 static constexpr PushButtonsConfig buttonConfig = {.numButtons = 2, .pins = BUTTON_PINS};
 
-DisplayDriver displayDriver;
 IMUDriver imuDriver;
 BuzzerDriver buzzerDriver{255};
 PushButtonsDriver buttonDriver{buttonConfig};
 M5MicDriver micDriver;
 
-// Forward declarations so ListeningOverlay::onDeactivate() can reach the
+// Forward declarations so VoiceDisplay::restoreContent() can reach the
 // idle prompt and the sandbox's run state; both are defined further down.
 extern Resident::Sandbox sandbox;
 static void showIdlePrompt();
 
-// "Listening" overlay: drawn while the front button is held. Bound to the
-// dual-role display in setup(), so activating it suspends the app.
-class ListeningOverlay : public Resident::Overlay {
+// The display's restoreContent() repaints what's underneath once the last
+// overlay claim on it releases. A resumed app repaints itself on its next
+// tick; on this example (no app loaded) that means the idle prompt.
+class VoiceDisplay : public DisplayDriver {
 public:
-  int priority() const override { return 100; }
-  void onDraw() override { displayDriver.displayText("Listening"); }
-
-  // The arbiter's restore() repaints the app on resume — but m5stick-voice
-  // never loads an app, so that path never fires. When there's no app to
-  // resume to, repaint the idle prompt ourselves so the screen doesn't stay
-  // stuck on "Listening" after release.
-  void onDeactivate() override {
+  void restoreContent() override {
     if (!sandbox.isAppRunning()) showIdlePrompt();
   }
+};
+VoiceDisplay displayDriver;
+
+// "Listening" overlay: a claim on the dual-role display while the front
+// button is held — the app (if any) is suspended for the duration. Static
+// text, so painting once in onAcquire is enough; no onDraw needed.
+class ListeningOverlay : public Resident::Overlay {
+public:
+  void onAcquire() override { displayDriver.displayText("Listening"); }
 };
 static ListeningOverlay listening;
 
@@ -97,7 +99,7 @@ void setup() {
         showIdlePrompt();
     });
 
-    sandbox.addOverlay(&listening, &displayDriver);
+    sandbox.addOverlay(&listening, &displayDriver, /*priority=*/100);
 
     // Push-to-talk: hold the front button → overlay + stream; release → stop.
     sandbox.onSystemButtonHold([](bool held) {

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.6.1"
+version: "0.6.2-dev"
 description: "Sandbox with hardware IO and hot reload for ESP32 devices"
 url: "https://github.com/inanimate-tech/resident"
 

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.6.2-dev"
+version: "0.6.2"
 description: "Sandbox with hardware IO and hot reload for ESP32 devices"
 url: "https://github.com/inanimate-tech/resident"
 
@@ -7,12 +7,14 @@ dependencies:
     version: ">=5.0.0"
   espressif/arduino-esp32:
     version: "^3.0.0"
-  # Courier 0.5.0: NTP-first time sync (robust HTTPS-Date fallback), larger
-  # receivable payloads on no-PSRAM boards, and per-transport endpoint state
-  # (Resident sets the WS endpoint via _ws.setEndpoint() inside
-  # onTransportsWillConnect(), which requires that surface).
+  # Courier: the surface Resident relies on landed in 0.5.0 — NTP-first time
+  # sync (robust HTTPS-Date fallback), larger receivable payloads on no-PSRAM
+  # boards, and per-transport endpoint state (Resident sets the WS endpoint via
+  # _ws.setEndpoint() inside onTransportsWillConnect(), which requires that
+  # surface). Pinned to ^0.5.1, which additionally enables the IDF certificate
+  # bundle by default on the WS and MQTT transports.
   inanimate/courier:
-    version: "^0.5.0"
+    version: "^0.5.1"
   bblanchon/arduinojson:
     version: "^7.0.0"
   # Esp32Lua is not on the ESP component registry. Consumers must provide it

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "resident",
-  "version": "0.6.2-dev",
+  "version": "0.6.2",
   "description": "Sandbox with hardware IO and hot reload for ESP32 devices",
   "keywords": "esp32, sandbox, iot, hot-reload",
   "repository": {
@@ -17,7 +17,7 @@
   "frameworks": ["arduino", "espidf"],
   "platforms": "espressif32",
   "dependencies": {
-    "inanimate/courier": "^0.5.0",
+    "inanimate/courier": "^0.5.1",
     "bblanchon/ArduinoJson": "^7.4.2",
     "fischer-simon/Esp32Lua": "^5.4.7"
   },

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "resident",
-  "version": "0.6.1",
+  "version": "0.6.2-dev",
   "description": "Sandbox with hardware IO and hot reload for ESP32 devices",
   "keywords": "esp32, sandbox, iot, hot-reload",
   "repository": {

--- a/src/ResidentOverlay.h
+++ b/src/ResidentOverlay.h
@@ -4,16 +4,34 @@
 
 namespace Resident {
 
-// A transient takeover of a display. The arbiter draws the highest-priority
-// requested overlay; whether it suspends the app is derived from the surface
-// it is bound to (see Sandbox::addOverlay / appDrawsTo), not declared here.
+// An overlay is a transient CLAIM on a display surface — a voice-recording
+// ring, an agent-status line — registered with Sandbox::addOverlay(overlay,
+// surface, priority) and toggled with Sandbox::requestOverlay.
+//
+// The arbiter resolves claims PER SURFACE: overlays bound to the same
+// surface contend by priority (highest wins; ties go to the earlier
+// registration), while overlays on different surfaces are independent. A
+// null surface means a dedicated surface — the overlay contends with
+// nothing, never suspends the app, and no restore is issued for it.
+//
+// While a claim is held on a surface the app also draws to (dual-role:
+// present in both extensions[] and a system* role slot), the app is
+// suspended; it resumes when the claim ends. When a surface's last claim
+// releases, the arbiter calls SystemDisplay::restoreContent() on the
+// surface — overlays never repaint what's underneath themselves.
 class Overlay {
 public:
-  virtual int  priority() const = 0;   // higher wins
-  virtual void onActivate()   {}       // became the winner
-  virtual void onDraw()       {}       // each loop while winning
-  virtual void onDeactivate() {}       // stopped winning
-  virtual void restore()      {}       // repaint the app's last frame
+  // You now own the surface. Paint the first frame here for immediate
+  // response; subsequent frames arrive via onDraw.
+  virtual void onAcquire()   {}
+  // Animation heartbeat while owning, paced on the sandbox app-tick cadence
+  // (the overlay effectively takes over the suspended app's tick slot).
+  // Event-driven repaints outside this callback are fine too.
+  virtual void onDraw(unsigned long dtMs) { (void)dtMs; }
+  // You no longer own the surface (a higher-priority claim took over, or
+  // the request was withdrawn). Wind down internal state only — the arbiter
+  // handles app resume and surface restore.
+  virtual void onRelease()   {}
   virtual ~Overlay() = default;
 };
 

--- a/src/ResidentSandbox.cpp
+++ b/src/ResidentSandbox.cpp
@@ -402,7 +402,9 @@ void Sandbox::deferAppLoads(bool defer)
     return;
   }
   const char* type = doc["type"] | "";
-  onCourierMessage("", type, doc);
+  // Route directly, skipping the filter (already applied at receipt) and the
+  // deferral guard (_deferLoads is now false).
+  dispatchMessage("", type, doc);
 }
 
 void Sandbox::onCourierMessage(const char* transportName,
@@ -426,6 +428,16 @@ void Sandbox::onCourierMessage(const char* transportName,
     return;
   }
 
+  dispatchMessage(transportName, type, doc);
+}
+
+// Reserved-type routing + user callback. Entered from onCourierMessage (after
+// the filter and deferral guards) and, for an applied stash, directly from
+// deferAppLoads — a stashed load already passed the filter at receipt, so
+// re-running it would let a dedup/self-echo filter drop the message.
+void Sandbox::dispatchMessage(const char* transportName,
+                              const char* type, JsonDocument& doc)
+{
   // Reserved types — Resident handles internally; user callback never sees these.
   if (strcmp(type, "app") == 0) {
     const char* code = doc["code"];

--- a/src/ResidentSandbox.cpp
+++ b/src/ResidentSandbox.cpp
@@ -3,6 +3,7 @@
 #include <ezTime.h>
 #include <math.h>
 #include <cassert>
+#include <cstdlib>
 #include "chipstring.h"
 #include "ResidentNvsStore.h"   // device-only; no-op on native
 
@@ -83,6 +84,10 @@ void Sandbox::configure(const SandboxConfig& config) {
 
 Sandbox::~Sandbox()
 {
+  if (_deferredLoadJson) {
+    free(_deferredLoadJson);
+    _deferredLoadJson = nullptr;
+  }
   if (_lua) {
     if (_initFuncRef != LUA_NOREF)
       luaL_unref(_lua, LUA_REGISTRYINDEX, _initFuncRef);
@@ -373,9 +378,54 @@ void Sandbox::wireInternalCourierHooks()
   });
 }
 
+void Sandbox::injectMessage(const char* transportName, const char* type,
+                            JsonDocument& doc)
+{
+  onCourierMessage(transportName, type, doc);
+}
+
+void Sandbox::deferAppLoads(bool defer)
+{
+  _deferLoads = defer;
+  if (defer || !_deferredLoadJson) return;
+
+  // Apply the stashed load now. Hand ownership to a local first: loadApp /
+  // loadShader may allocate heavily, and re-entrant stashing must see a
+  // clean slot.
+  char* payload = _deferredLoadJson;
+  _deferredLoadJson = nullptr;
+  JsonDocument doc;
+  DeserializationError err = deserializeJson(doc, payload);
+  free(payload);
+  if (err) {
+    Serial.println("Resident::Sandbox: deferred load unparseable; dropped");
+    return;
+  }
+  const char* type = doc["type"] | "";
+  onCourierMessage("", type, doc);
+}
+
 void Sandbox::onCourierMessage(const char* transportName,
                                 const char* type, JsonDocument& doc)
 {
+  // Platform filter runs before everything; false = consumed.
+  if (_messageFilter && !_messageFilter(transportName, type, doc)) return;
+
+  // App-load deferral: stash (last one wins) instead of loading.
+  if (_deferLoads &&
+      (strcmp(type, "app") == 0 || strcmp(type, "shader") == 0)) {
+    size_t need = measureJson(doc) + 1;
+    char* stash = (char*)malloc(need);
+    if (!stash) {
+      Serial.println("Resident::Sandbox: deferred load alloc failed; dropped");
+      return;
+    }
+    serializeJson(doc, stash, need);
+    if (_deferredLoadJson) free(_deferredLoadJson);
+    _deferredLoadJson = stash;
+    return;
+  }
+
   // Reserved types — Resident handles internally; user callback never sees these.
   if (strcmp(type, "app") == 0) {
     const char* code = doc["code"];
@@ -578,9 +628,11 @@ bool Sandbox::loadAppInternal(const char* luaCode, bool persistOnSuccess)
 
   // Stop any currently-loaded app (Running or Suspended) before loading the
   // new one. A freshly loaded app starts Running, never Suspended — compileApp
-  // sets that below.
+  // sets that below. Any arbiter-held suspension died with the old app; the
+  // post-load reconcile re-suspends the new app if a claim is still held.
   if (isAppRunning()) {
     _runState = RunState::Ready;
+    _overlaySuspendedApp = false;
     notifyAppRunning(false);
   }
 
@@ -604,6 +656,10 @@ bool Sandbox::loadAppInternal(const char* luaCode, bool persistOnSuccess)
   }
 
   bool loadedOk = compiled && _lastInitOk;
+
+  // An app loaded while a dual-role overlay claim is held starts suspended
+  // rather than ticking (and drawing) beneath the overlay.
+  if (loadedOk) reconcileOverlaySuspension();
 
   // Persist only an app we know loaded cleanly, and never re-persist a restore.
   if (persistOnSuccess && loadedOk && _config.persistApps && _store) {
@@ -734,29 +790,38 @@ bool Sandbox::appDrawsTo(SystemDisplay* surface) const
   return surface && isSystemExtension(e) && isAppExtension(e);
 }
 
-void Sandbox::addOverlay(Overlay* o, SystemDisplay* surface)
+void Sandbox::addOverlay(Overlay* o, SystemDisplay* surface, int priority)
 {
   if (!o || _overlayCount >= MAX_OVERLAYS) return;
-  _overlays[_overlayCount++] = {o, surface, false};
+  _overlays[_overlayCount++] = {o, surface, priority, false, false};
 }
 
 void Sandbox::removeOverlay(Overlay* o)
 {
   for (uint8_t i = 0; i < _overlayCount; i++) {
-    if (_overlays[i].o == o) {
-      for (uint8_t j = i; j + 1 < _overlayCount; j++) _overlays[j] = _overlays[j + 1];
-      _overlayCount--;
-      if (_activeOverlay == o) {
-        o->onDeactivate();
-        if (_overlaySuspendedApp) {
-          resumeApp();
-          _overlaySuspendedApp = false;
-          o->restore();
+    if (_overlays[i].o != o) continue;
+    bool wasWinning = _overlays[i].winning;
+    SystemDisplay* surface = _overlays[i].surface;
+    if (wasWinning) o->onRelease();
+    for (uint8_t j = i; j + 1 < _overlayCount; j++) _overlays[j] = _overlays[j + 1];
+    _overlayCount--;
+    if (wasWinning) {
+      // Promote any successor on this surface and reconcile suspension in
+      // one arbitration pass; restore the surface only if no successor
+      // claimed it (updateOverlays can't see the removed slot's release).
+      updateOverlays();
+      if (surface) {
+        bool stillClaimed = false;
+        for (uint8_t j = 0; j < _overlayCount; j++) {
+          if (_overlays[j].winning && _overlays[j].surface == surface) {
+            stillClaimed = true;
+            break;
+          }
         }
-        _activeOverlay = nullptr;
+        if (!stillClaimed) surface->restoreContent();
       }
-      return;
     }
+    return;
   }
 }
 
@@ -767,39 +832,102 @@ void Sandbox::requestOverlay(Overlay* o, bool active)
   }
 }
 
+// Suspend the app iff any winning claim sits on a dual-role surface. Only a
+// suspension the arbiter itself performed is ever resumed here, so a
+// device-initiated suspendApp() survives overlay churn untouched.
+void Sandbox::reconcileOverlaySuspension()
+{
+  bool wantSuspend = false;
+  for (uint8_t i = 0; i < _overlayCount; i++) {
+    if (_overlays[i].winning && appDrawsTo(_overlays[i].surface)) {
+      wantSuspend = true;
+      break;
+    }
+  }
+  if (wantSuspend && !_overlaySuspendedApp && _runState == RunState::Running) {
+    suspendApp();
+    _overlaySuspendedApp = true;
+  } else if (!wantSuspend && _overlaySuspendedApp) {
+    _overlaySuspendedApp = false;
+    resumeApp();
+  }
+}
+
 void Sandbox::updateOverlays()
 {
-  // Winner = highest-priority requested overlay.
-  Overlay* winner = nullptr;
-  SystemDisplay* winnerSurface = nullptr;
-  bool have = false;
-  int best = 0;
+  // Phase 1: per-surface winners. A slot wins iff requested and no other
+  // requested slot on the SAME (non-null) surface outranks it — higher
+  // priority, or equal priority registered earlier. A null surface is
+  // dedicated: the slot contends with nothing and wins whenever requested.
+  bool newWinning[MAX_OVERLAYS];
   for (uint8_t i = 0; i < _overlayCount; i++) {
-    if (!_overlays[i].requested) continue;
-    int p = _overlays[i].o->priority();
-    if (!have || p > best) {
-      have = true; best = p; winner = _overlays[i].o; winnerSurface = _overlays[i].surface;
+    OverlaySlot& s = _overlays[i];
+    bool win = s.requested;
+    if (win && s.surface) {
+      for (uint8_t j = 0; j < _overlayCount; j++) {
+        if (j == i) continue;
+        OverlaySlot& t = _overlays[j];
+        if (!t.requested || t.surface != s.surface) continue;
+        if (t.priority > s.priority ||
+            (t.priority == s.priority && j < i)) {
+          win = false;
+          break;
+        }
+      }
+    }
+    newWinning[i] = win;
+  }
+
+  // Phase 2: releases before acquires, remembering which non-null surfaces
+  // lost their winner (at most one winner per surface, so no dedup needed).
+  SystemDisplay* releasedSurfaces[MAX_OVERLAYS];
+  uint8_t releasedCount = 0;
+  for (uint8_t i = 0; i < _overlayCount; i++) {
+    if (_overlays[i].winning && !newWinning[i]) {
+      _overlays[i].winning = false;
+      _overlays[i].o->onRelease();
+      if (_overlays[i].surface) {
+        releasedSurfaces[releasedCount++] = _overlays[i].surface;
+      }
     }
   }
 
-  if (winner != _activeOverlay) {
-    Overlay* prev = _activeOverlay;
-    if (prev) prev->onDeactivate();
-    _activeOverlay = winner;
-    if (winner) winner->onActivate();
-
-    bool wantSuspend = winner && appDrawsTo(winnerSurface);
-    if (wantSuspend && !_overlaySuspendedApp && _runState == RunState::Running) {
-      suspendApp();
-      _overlaySuspendedApp = true;
-    } else if (!wantSuspend && _overlaySuspendedApp) {
-      resumeApp();
-      _overlaySuspendedApp = false;
-      if (prev) prev->restore();
+  // Phase 3: acquires.
+  for (uint8_t i = 0; i < _overlayCount; i++) {
+    if (!_overlays[i].winning && newWinning[i]) {
+      _overlays[i].winning = true;
+      _overlays[i].o->onAcquire();
     }
   }
 
-  if (_activeOverlay) _activeOverlay->onDraw();
+  // Phase 4: app suspension tracks the winning set.
+  reconcileOverlaySuspension();
+
+  // Phase 5: a surface whose last claim just released repaints its
+  // underlying content — after the resume above (so the app is live again),
+  // and never on a handoff (the surface still has a winner then).
+  for (uint8_t r = 0; r < releasedCount; r++) {
+    bool stillClaimed = false;
+    for (uint8_t i = 0; i < _overlayCount; i++) {
+      if (_overlays[i].winning && _overlays[i].surface == releasedSurfaces[r]) {
+        stillClaimed = true;
+        break;
+      }
+    }
+    if (!stillClaimed) releasedSurfaces[r]->restoreContent();
+  }
+
+  // Phase 6: winning overlays draw on the app-tick cadence — the overlay
+  // takes over the (suspended) app's tick slot. onAcquire already painted
+  // the first frame; event-driven repaints outside onDraw remain fine.
+  unsigned long now = millis();
+  unsigned long elapsed = now - _lastOverlayDrawTime;
+  if (elapsed >= TICK_INTERVAL) {
+    _lastOverlayDrawTime = now;
+    for (uint8_t i = 0; i < _overlayCount; i++) {
+      if (_overlays[i].winning) _overlays[i].o->onDraw(elapsed);
+    }
+  }
 }
 
 void Sandbox::finishBootCountdown()

--- a/src/ResidentSandbox.h
+++ b/src/ResidentSandbox.h
@@ -160,7 +160,9 @@ public:
     // Defer app/shader loads (e.g. during a voice recording, when a Lua
     // compile would stall the audio path). While set, incoming app/shader
     // messages are stashed — last one wins — instead of loaded; clearing
-    // applies the stashed load immediately. Other types flow normally.
+    // applies the stashed load immediately, routing it straight to loading
+    // without re-running the filter (it already passed at receipt, so a dedup
+    // filter won't drop it a second time). Other types flow normally.
     void deferAppLoads(bool defer);
     bool hasDeferredAppLoad() const { return _deferredLoadJson != nullptr; }
 
@@ -238,6 +240,10 @@ private:
     void wireInternalCourierHooks();
     void onCourierMessage(const char* transportName, const char* type,
                           JsonDocument& doc);
+    // Reserved-type routing + user callback, below the filter/deferral guards.
+    // Called directly when an applied stash must bypass a re-filter.
+    void dispatchMessage(const char* transportName, const char* type,
+                         JsonDocument& doc);
     void onCourierConnectionChange(Courier::State state);
     void onCourierConnected();
     void onCourierTransportsWillConnect();

--- a/src/ResidentSandbox.h
+++ b/src/ResidentSandbox.h
@@ -93,11 +93,15 @@ public:
     void stopMicStream();
     bool isMicStreaming() const { return _micStreaming; }
 
-    // Overlay support. Register an overlay bound to the display surface it
-    // draws on; toggle its desired state with requestOverlay. The arbiter draws
-    // the highest-priority active overlay each loop; if that overlay's surface
-    // is dual-role (appDrawsTo), the app is suspended while it shows.
-    void addOverlay(Overlay* o, SystemDisplay* surface);
+    // Overlay support. Register an overlay as a claim on the display surface
+    // it draws to (nullptr = a dedicated surface: never contends, never
+    // suspends the app); toggle its desired state with requestOverlay. The
+    // arbiter resolves claims PER SURFACE — the highest-priority requested
+    // overlay on each surface wins (ties: earlier registration) and receives
+    // onAcquire / tick-paced onDraw / onRelease. While any winning overlay's
+    // surface is dual-role (appDrawsTo), the app is suspended. When a
+    // surface's last claim releases, the arbiter calls its restoreContent().
+    void addOverlay(Overlay* o, SystemDisplay* surface, int priority);
     void removeOverlay(Overlay* o);
     void requestOverlay(Overlay* o, bool active);
 
@@ -140,6 +144,31 @@ public:
     void onConnected(ConnectedCallback cb) {
       _onConnected = std::move(cb);
     }
+
+    // ── Message interposition ──
+    // Pre-routing filter (single-slot). Runs before app-load deferral,
+    // reserved-type routing (app/shader/app_event/forget), and the user
+    // onMessage callback. Return true to continue normal routing; return
+    // false to consume the message (nothing further runs). Platform wrappers
+    // use this for dedup, self-echo filtering, and platform-only message
+    // types — without re-implementing the sandbox's routing.
+    using MessageFilter = std::function<bool(const char* transportName,
+                                              const char* type,
+                                              JsonDocument& doc)>;
+    void onMessageFilter(MessageFilter cb) { _messageFilter = std::move(cb); }
+
+    // Defer app/shader loads (e.g. during a voice recording, when a Lua
+    // compile would stall the audio path). While set, incoming app/shader
+    // messages are stashed — last one wins — instead of loaded; clearing
+    // applies the stashed load immediately. Other types flow normally.
+    void deferAppLoads(bool defer);
+    bool hasDeferredAppLoad() const { return _deferredLoadJson != nullptr; }
+
+    // Route a message through the sandbox exactly as if it arrived from a
+    // transport (filter → deferral → reserved-type routing → user callback).
+    // For wrappers with their own receive path, and for native tests.
+    void injectMessage(const char* transportName, const char* type,
+                       JsonDocument& doc);
 
     // ── Identity / status accessors ──
     const String& getDeviceId() const { return _deviceId; }
@@ -195,6 +224,14 @@ private:
     MessageCallback               _onMessage;
     ConnectionChangeCallback      _onConnectionChange;
     ConnectedCallback             _onConnected;
+    MessageFilter                 _messageFilter;
+
+    // Deferred app/shader load: a heap-owned serialized copy of the last
+    // stashed message (nullptr = none). Raw malloc, not String, so the stash
+    // costs one allocation during the memory-sensitive window that deferral
+    // exists for. Freed on apply, overwrite, and destruction.
+    bool  _deferLoads = false;
+    char* _deferredLoadJson = nullptr;
 
     // Internal Courier hook handlers (drive status indicators + reserved-type
     // routing, then delegate to user callbacks).
@@ -296,22 +333,27 @@ private:
     int16_t _micBuf[MIC_STREAM_MAX_SAMPLES] = {};
     void updateMicStream();
 
-    // Overlay arbiter state.
+    // Overlay arbiter state. Winners are tracked per slot (per-surface
+    // arbitration — see updateOverlays); _overlaySuspendedApp marks a
+    // suspension the ARBITER performed, so a device-initiated suspendApp()
+    // is never resumed by an overlay releasing.
     static constexpr int MAX_OVERLAYS = 4;
-    struct OverlaySlot { Overlay* o; SystemDisplay* surface; bool requested; };
+    struct OverlaySlot {
+        Overlay* o;
+        SystemDisplay* surface;   // nullptr = dedicated surface
+        int priority;
+        bool requested;
+        bool winning;
+    };
     OverlaySlot _overlays[MAX_OVERLAYS] = {};
     uint8_t _overlayCount = 0;
-    // Known limitations (fine for current single-overlay-per-device use;
-    // revisit for the Hawthorn port which loads apps under overlays):
-    // (1) loadApp() while an overlay is active does not reconcile these — a
-    //     new app can tick under a held overlay until release.
-    // (2) the arbiter assumes it is the first suspender: if device code
-    //     calls suspendApp() before an overlay activates, the arbiter's
-    //     resume on deactivate will resume an app the device wanted
-    //     suspended.
-    Overlay* _activeOverlay = nullptr;
     bool _overlaySuspendedApp = false;
+    unsigned long _lastOverlayDrawTime = 0;
     void updateOverlays();
+    // Suspend/resume the app to match the current winning claims. Called
+    // from the arbiter and from loadAppInternal (an app loaded under a held
+    // dual-role overlay starts suspended rather than ticking beneath it).
+    void reconcileOverlaySuspension();
     // True iff e is a declared (app-facing) extension.
     bool isAppExtension(Extension* e) const;
     // True iff the app draws to surface (dual-role: system slot AND app ext).

--- a/src/ResidentSystemDisplay.h
+++ b/src/ResidentSystemDisplay.h
@@ -11,6 +11,13 @@ namespace Resident {
 class SystemDisplay : public Driver {
 public:
   virtual void displayText(const char* text) = 0;
+
+  // Repaint the surface's underlying content (last app frame, idle screen,
+  // prior status text) after the last overlay claiming this surface
+  // releases. Called by the overlay arbiter — overlays themselves never
+  // restore. Default no-op: correct for dedicated surfaces with nothing
+  // underneath.
+  virtual void restoreContent() {}
 };
 
 } // namespace Resident

--- a/test/unit/test/test_message_routing/test_message_routing.cpp
+++ b/test/unit/test/test_message_routing/test_message_routing.cpp
@@ -133,6 +133,28 @@ void test_clearing_empty_defer_is_noop(void) {
   TEST_ASSERT_FALSE(sandbox->hasDeferredAppLoad());
 }
 
+void test_deferred_apply_does_not_refilter(void) {
+  // The filter accepted the message once, at receipt. Applying the stash must
+  // route it straight through — re-running the filter would let a dedup /
+  // self-echo filter drop the message on its second sight, and the deferred
+  // app would silently never load.
+  build();
+  static int appFilterCalls = 0;
+  appFilterCalls = 0;
+  sandbox->onMessageFilter([](const char*, const char* type, JsonDocument&) {
+    if (strcmp(type, "app") != 0) return true;
+    return ++appFilterCalls == 1;          // dedup: only the first app passes
+  });
+  sandbox->deferAppLoads(true);
+  injectApp(APP_A);                        // filtered once (passes), then stashed
+  TEST_ASSERT_TRUE(sandbox->hasDeferredAppLoad());
+
+  sandbox->deferAppLoads(false);           // apply must not re-run the filter
+  TEST_ASSERT_TRUE(sandbox->isAppRunning());
+  TEST_ASSERT_TRUE(sandbox->luaGlobalBoolForTest("flagA"));
+  TEST_ASSERT_EQUAL_INT(1, appFilterCalls);
+}
+
 int main(int, char**) {
   UNITY_BEGIN();
   RUN_TEST(test_inject_routes_reserved_types);
@@ -144,6 +166,7 @@ int main(int, char**) {
   RUN_TEST(test_defer_does_not_touch_other_types);
   RUN_TEST(test_filter_runs_before_deferral);
   RUN_TEST(test_clearing_empty_defer_is_noop);
+  RUN_TEST(test_deferred_apply_does_not_refilter);
   UNITY_END();
   return 0;
 }

--- a/test/unit/test/test_message_routing/test_message_routing.cpp
+++ b/test/unit/test/test_message_routing/test_message_routing.cpp
@@ -1,0 +1,149 @@
+// Message interposition: onMessageFilter runs before deferral, reserved-type
+// routing, and the user onMessage callback; deferAppLoads stashes app/shader
+// loads (last one wins) and applies the stash when cleared. injectMessage is
+// the transport-independent entry into that pipeline.
+#include <unity.h>
+#include "ResidentSandbox.cpp"
+
+namespace {
+Resident::Sandbox* sandbox = nullptr;
+
+constexpr const char* APP_A =
+    "function init(ctx) flagA = true end\nfunction on_tick(ctx, dt) end\n";
+constexpr const char* APP_B =
+    "function init(ctx) flagB = true end\nfunction on_tick(ctx, dt) end\n";
+
+void build() {
+  Resident::SandboxConfig cfg;
+  cfg.deviceType = "native-test";
+  sandbox = new Resident::Sandbox(cfg);
+  sandbox->setup();
+}
+
+void injectApp(const char* code) {
+  JsonDocument doc;
+  doc["type"] = "app";
+  doc["code"] = code;
+  sandbox->injectMessage("test", "app", doc);
+}
+}  // namespace
+
+void setUp(void) { testMillis() = 0; }
+void tearDown(void) { delete sandbox; sandbox = nullptr; }
+
+void test_inject_routes_reserved_types(void) {
+  build();
+  injectApp(APP_A);
+  TEST_ASSERT_TRUE(sandbox->isAppRunning());
+  TEST_ASSERT_TRUE(sandbox->luaGlobalBoolForTest("flagA"));
+}
+
+void test_filter_consumes_message(void) {
+  build();
+  sandbox->onMessageFilter([](const char*, const char* type, JsonDocument&) {
+    return strcmp(type, "app") != 0;   // swallow app loads
+  });
+  injectApp(APP_A);
+  TEST_ASSERT_FALSE(sandbox->isAppRunning());
+}
+
+void test_filter_passes_message_through(void) {
+  build();
+  int seen = 0;
+  sandbox->onMessageFilter([&](const char*, const char*, JsonDocument&) {
+    seen++;
+    return true;
+  });
+  injectApp(APP_A);
+  TEST_ASSERT_EQUAL_INT(1, seen);
+  TEST_ASSERT_TRUE(sandbox->isAppRunning());
+}
+
+void test_filter_runs_before_user_callback(void) {
+  build();
+  static int order = 0;
+  static int filterAt = 0, userAt = 0;
+  order = filterAt = userAt = 0;
+  sandbox->onMessageFilter([](const char*, const char*, JsonDocument&) {
+    filterAt = ++order;
+    return true;
+  });
+  sandbox->onMessage([](const char*, const char*, JsonDocument&) {
+    userAt = ++order;
+  });
+  JsonDocument doc;
+  doc["type"] = "custom";
+  sandbox->injectMessage("test", "custom", doc);
+  TEST_ASSERT_EQUAL_INT(1, filterAt);
+  TEST_ASSERT_EQUAL_INT(2, userAt);
+}
+
+void test_defer_stashes_then_applies(void) {
+  build();
+  sandbox->deferAppLoads(true);
+  injectApp(APP_A);
+  TEST_ASSERT_FALSE(sandbox->isAppRunning());
+  TEST_ASSERT_TRUE(sandbox->hasDeferredAppLoad());
+
+  sandbox->deferAppLoads(false);
+  TEST_ASSERT_FALSE(sandbox->hasDeferredAppLoad());
+  TEST_ASSERT_TRUE(sandbox->isAppRunning());
+  TEST_ASSERT_TRUE(sandbox->luaGlobalBoolForTest("flagA"));
+}
+
+void test_defer_last_one_wins(void) {
+  build();
+  sandbox->deferAppLoads(true);
+  injectApp(APP_A);
+  injectApp(APP_B);
+  sandbox->deferAppLoads(false);
+  TEST_ASSERT_TRUE(sandbox->isAppRunning());
+  TEST_ASSERT_FALSE(sandbox->luaGlobalBoolForTest("flagA"));
+  TEST_ASSERT_TRUE(sandbox->luaGlobalBoolForTest("flagB"));
+}
+
+void test_defer_does_not_touch_other_types(void) {
+  build();
+  static int userCalls = 0;
+  userCalls = 0;
+  sandbox->deferAppLoads(true);
+  sandbox->onMessage([](const char*, const char*, JsonDocument&) { userCalls++; });
+  JsonDocument doc;
+  doc["type"] = "custom";
+  sandbox->injectMessage("test", "custom", doc);
+  TEST_ASSERT_EQUAL_INT(1, userCalls);          // flowed normally
+  TEST_ASSERT_FALSE(sandbox->hasDeferredAppLoad());
+}
+
+void test_filter_runs_before_deferral(void) {
+  build();
+  sandbox->deferAppLoads(true);
+  sandbox->onMessageFilter([](const char*, const char* type, JsonDocument&) {
+    return strcmp(type, "app") != 0;   // consume app before deferral sees it
+  });
+  injectApp(APP_A);
+  TEST_ASSERT_FALSE(sandbox->hasDeferredAppLoad());
+}
+
+void test_clearing_empty_defer_is_noop(void) {
+  build();
+  sandbox->deferAppLoads(true);
+  sandbox->deferAppLoads(false);
+  TEST_ASSERT_FALSE(sandbox->isAppRunning());
+  TEST_ASSERT_FALSE(sandbox->hasDeferredAppLoad());
+}
+
+int main(int, char**) {
+  UNITY_BEGIN();
+  RUN_TEST(test_inject_routes_reserved_types);
+  RUN_TEST(test_filter_consumes_message);
+  RUN_TEST(test_filter_passes_message_through);
+  RUN_TEST(test_filter_runs_before_user_callback);
+  RUN_TEST(test_defer_stashes_then_applies);
+  RUN_TEST(test_defer_last_one_wins);
+  RUN_TEST(test_defer_does_not_touch_other_types);
+  RUN_TEST(test_filter_runs_before_deferral);
+  RUN_TEST(test_clearing_empty_defer_is_noop);
+  UNITY_END();
+  return 0;
+}

--- a/test/unit/test/test_overlay/test_overlay.cpp
+++ b/test/unit/test/test_overlay/test_overlay.cpp
@@ -1,33 +1,35 @@
-// Overlay arbiter: highest-priority requested overlay draws; a dual-role
-// surface (in extensions[] AND systemDisplay) suspends the app; a dedicated
-// surface does not.
+// Overlay arbiter: claims are resolved PER SURFACE (highest priority wins,
+// ties to earlier registration; distinct surfaces are independent). A
+// dual-role surface (in extensions[] AND systemDisplay) suspends the app
+// while claimed; the arbiter calls SystemDisplay::restoreContent() when a
+// surface's last claim releases. onDraw is paced on the app-tick cadence.
 #include <unity.h>
 #include "ResidentSandbox.cpp"
 
 namespace {
 class SpyDisplay : public Resident::SystemDisplay {
 public:
+  int restores = 0;
   const char* name() const override { return "display"; }
   void update() override {}
   void displayText(const char* t) override { (void)t; }
+  void restoreContent() override { restores++; }
 };
 
 class FakeOverlay : public Resident::Overlay {
 public:
-  int prio;
-  int activates = 0, deactivates = 0, draws = 0, restores = 0;
-  explicit FakeOverlay(int p) : prio(p) {}
-  int priority() const override { return prio; }
-  void onActivate() override { activates++; }
-  void onDraw() override { draws++; }
-  void onDeactivate() override { deactivates++; }
-  void restore() override { restores++; }
+  int acquires = 0, releases = 0, draws = 0;
+  unsigned long lastDt = 0;
+  void onAcquire() override { acquires++; }
+  void onDraw(unsigned long dt) override { draws++; lastDt = dt; }
+  void onRelease() override { releases++; }
 };
 
 constexpr const char* APP =
     "function init(ctx) end\nfunction on_tick(ctx, dt) end\n";
 
 SpyDisplay* disp = nullptr;
+SpyDisplay* disp2 = nullptr;
 Resident::Sandbox* sandbox = nullptr;
 
 void runLoop(int n) { for (int i = 0; i < n; i++) { testMillis() += 200; sandbox->loop(); } }
@@ -44,44 +46,49 @@ void buildDualRole() {
 }
 }  // namespace
 
-void tearDown(void) { delete sandbox; sandbox = nullptr; delete disp; disp = nullptr; }
+void tearDown(void) {
+  delete sandbox; sandbox = nullptr;
+  delete disp; disp = nullptr;
+  delete disp2; disp2 = nullptr;
+}
 void setUp(void) { testMillis() = 0; }
 
-void test_dual_role_overlay_suspends_and_restores(void) {
+void test_dual_role_overlay_suspends_and_restores_surface(void) {
   buildDualRole();
   sandbox->loadApp(APP);
-  FakeOverlay ov(100);
-  sandbox->addOverlay(&ov, disp);
+  FakeOverlay ov;
+  sandbox->addOverlay(&ov, disp, 100);
 
   sandbox->requestOverlay(&ov, true);
   runLoop(1);
-  TEST_ASSERT_EQUAL_INT(1, ov.activates);
+  TEST_ASSERT_EQUAL_INT(1, ov.acquires);
   TEST_ASSERT_EQUAL_INT(1, ov.draws);
   TEST_ASSERT_TRUE(sandbox->isAppSuspended());
 
   sandbox->requestOverlay(&ov, false);
   runLoop(1);
-  TEST_ASSERT_EQUAL_INT(1, ov.deactivates);
-  TEST_ASSERT_EQUAL_INT(1, ov.restores);
+  TEST_ASSERT_EQUAL_INT(1, ov.releases);
+  TEST_ASSERT_EQUAL_INT(1, disp->restores);      // surface restores, not overlay
   TEST_ASSERT_FALSE(sandbox->isAppSuspended());
 }
 
 void test_priority_arbitration(void) {
   buildDualRole();
   sandbox->loadApp(APP);
-  FakeOverlay hi(100), lo(50);
-  sandbox->addOverlay(&hi, disp);
-  sandbox->addOverlay(&lo, disp);
+  FakeOverlay hi, lo;
+  sandbox->addOverlay(&hi, disp, 100);
+  sandbox->addOverlay(&lo, disp, 50);
 
   sandbox->requestOverlay(&hi, true);
   sandbox->requestOverlay(&lo, true);
   runLoop(1);
-  TEST_ASSERT_EQUAL_INT(1, hi.activates);   // higher wins
-  TEST_ASSERT_EQUAL_INT(0, lo.activates);
+  TEST_ASSERT_EQUAL_INT(1, hi.acquires);    // higher wins
+  TEST_ASSERT_EQUAL_INT(0, lo.acquires);
 
   sandbox->requestOverlay(&hi, false);
   runLoop(1);
-  TEST_ASSERT_EQUAL_INT(1, lo.activates);   // lower takes over
+  TEST_ASSERT_EQUAL_INT(1, lo.acquires);    // lower takes over
+  TEST_ASSERT_EQUAL_INT(0, disp->restores); // handoff: surface never released
 }
 
 void test_dedicated_surface_does_not_suspend(void) {
@@ -94,19 +101,74 @@ void test_dedicated_surface_does_not_suspend(void) {
   sandbox->setup();
   sandbox->loadApp(APP);
 
-  FakeOverlay ov(100);
-  sandbox->addOverlay(&ov, disp);
+  FakeOverlay ov;
+  sandbox->addOverlay(&ov, disp, 100);
   sandbox->requestOverlay(&ov, true);
   runLoop(1);
   TEST_ASSERT_EQUAL_INT(1, ov.draws);
   TEST_ASSERT_FALSE(sandbox->isAppSuspended());  // app keeps running
 }
 
+void test_null_surface_is_independent(void) {
+  // Two claims on DIFFERENT surfaces (one null = dedicated) are independent:
+  // both win concurrently regardless of priority.
+  buildDualRole();
+  sandbox->loadApp(APP);
+  FakeOverlay onShared, onDedicated;
+  sandbox->addOverlay(&onShared, disp, 100);
+  sandbox->addOverlay(&onDedicated, nullptr, 1);   // lower priority, own surface
+
+  sandbox->requestOverlay(&onShared, true);
+  sandbox->requestOverlay(&onDedicated, true);
+  runLoop(1);
+  TEST_ASSERT_EQUAL_INT(1, onShared.acquires);
+  TEST_ASSERT_EQUAL_INT(1, onDedicated.acquires);  // not outranked — no contest
+  TEST_ASSERT_EQUAL_INT(1, onShared.draws);
+  TEST_ASSERT_EQUAL_INT(1, onDedicated.draws);
+
+  // Releasing the shared claim doesn't touch the dedicated one.
+  sandbox->requestOverlay(&onShared, false);
+  runLoop(1);
+  TEST_ASSERT_EQUAL_INT(1, onShared.releases);
+  TEST_ASSERT_EQUAL_INT(0, onDedicated.releases);
+  TEST_ASSERT_EQUAL_INT(1, disp->restores);
+  TEST_ASSERT_FALSE(sandbox->isAppSuspended());
+}
+
+void test_two_surfaces_arbitrate_independently(void) {
+  // time-p1 shape: status overlay on the (role-only) system display, voice
+  // overlay on its own dedicated surface — both draw at once.
+  disp = new SpyDisplay();
+  disp2 = new SpyDisplay();
+  Resident::SandboxConfig cfg;
+  cfg.deviceType = "native-test";
+  cfg.systemDisplay = disp;
+  sandbox = new Resident::Sandbox(cfg);
+  sandbox->setup();
+  sandbox->loadApp(APP);
+
+  FakeOverlay voice, status;
+  sandbox->addOverlay(&voice, disp2, 100);
+  sandbox->addOverlay(&status, disp, 50);
+
+  sandbox->requestOverlay(&voice, true);
+  sandbox->requestOverlay(&status, true);
+  runLoop(1);
+  TEST_ASSERT_EQUAL_INT(1, voice.acquires);
+  TEST_ASSERT_EQUAL_INT(1, status.acquires);   // different surface — no contest
+
+  sandbox->requestOverlay(&voice, false);
+  runLoop(1);
+  TEST_ASSERT_EQUAL_INT(1, disp2->restores);
+  TEST_ASSERT_EQUAL_INT(0, disp->restores);
+  TEST_ASSERT_EQUAL_INT(0, status.releases);   // untouched by voice releasing
+}
+
 void test_remove_active_overlay_resumes_app(void) {
   buildDualRole();
   sandbox->loadApp(APP);
-  FakeOverlay ov(100);
-  sandbox->addOverlay(&ov, disp);
+  FakeOverlay ov;
+  sandbox->addOverlay(&ov, disp, 100);
 
   sandbox->requestOverlay(&ov, true);
   runLoop(1);
@@ -114,8 +176,8 @@ void test_remove_active_overlay_resumes_app(void) {
 
   sandbox->removeOverlay(&ov);
   TEST_ASSERT_FALSE(sandbox->isAppSuspended());
-  TEST_ASSERT_EQUAL_INT(1, ov.deactivates);
-  TEST_ASSERT_EQUAL_INT(1, ov.restores);
+  TEST_ASSERT_EQUAL_INT(1, ov.releases);
+  TEST_ASSERT_EQUAL_INT(1, disp->restores);
 
   runLoop(1);
   TEST_ASSERT_FALSE(sandbox->isAppSuspended());  // no relapse
@@ -124,9 +186,9 @@ void test_remove_active_overlay_resumes_app(void) {
 void test_swap_between_dual_role_overlays_keeps_suspended_no_restore(void) {
   buildDualRole();
   sandbox->loadApp(APP);
-  FakeOverlay hi(100), lo(50);
-  sandbox->addOverlay(&hi, disp);
-  sandbox->addOverlay(&lo, disp);
+  FakeOverlay hi, lo;
+  sandbox->addOverlay(&hi, disp, 100);
+  sandbox->addOverlay(&lo, disp, 50);
 
   sandbox->requestOverlay(&hi, true);
   sandbox->requestOverlay(&lo, true);
@@ -135,19 +197,73 @@ void test_swap_between_dual_role_overlays_keeps_suspended_no_restore(void) {
 
   sandbox->requestOverlay(&hi, false);
   runLoop(1);
-  TEST_ASSERT_EQUAL_INT(1, lo.activates);
-  TEST_ASSERT_EQUAL_INT(1, hi.deactivates);
+  TEST_ASSERT_EQUAL_INT(1, lo.acquires);
+  TEST_ASSERT_EQUAL_INT(1, hi.releases);
   TEST_ASSERT_TRUE(sandbox->isAppSuspended());   // handoff to lo, still suspended
-  TEST_ASSERT_EQUAL_INT(0, hi.restores);         // no restore during dual-role handoff
+  TEST_ASSERT_EQUAL_INT(0, disp->restores);      // no restore during handoff
+}
+
+void test_app_loaded_under_claim_starts_suspended(void) {
+  buildDualRole();
+  FakeOverlay ov;
+  sandbox->addOverlay(&ov, disp, 100);
+  sandbox->requestOverlay(&ov, true);
+  runLoop(1);
+  TEST_ASSERT_EQUAL_INT(1, ov.acquires);
+
+  // App arrives while the claim is held: it must not tick under the overlay.
+  sandbox->loadApp(APP);
+  TEST_ASSERT_TRUE(sandbox->isAppSuspended());
+
+  sandbox->requestOverlay(&ov, false);
+  runLoop(1);
+  TEST_ASSERT_FALSE(sandbox->isAppSuspended());
+}
+
+void test_device_suspension_survives_overlay_cycle(void) {
+  buildDualRole();
+  sandbox->loadApp(APP);
+  sandbox->suspendApp();                     // device-initiated
+  FakeOverlay ov;
+  sandbox->addOverlay(&ov, disp, 100);
+
+  sandbox->requestOverlay(&ov, true);
+  runLoop(1);
+  TEST_ASSERT_TRUE(sandbox->isAppSuspended());
+
+  sandbox->requestOverlay(&ov, false);
+  runLoop(1);
+  // The arbiter didn't suspend, so it must not resume.
+  TEST_ASSERT_TRUE(sandbox->isAppSuspended());
+}
+
+void test_draw_paced_on_tick_cadence(void) {
+  buildDualRole();
+  sandbox->loadApp(APP);
+  FakeOverlay ov;
+  sandbox->addOverlay(&ov, disp, 100);
+  sandbox->requestOverlay(&ov, true);
+
+  // Loop steps of 20ms: with TICK_INTERVAL=100 only every 5th loop draws.
+  int drawsBefore = ov.draws;
+  for (int i = 0; i < 10; i++) { testMillis() += 20; sandbox->loop(); }
+  int drawn = ov.draws - drawsBefore;
+  TEST_ASSERT_TRUE(drawn >= 2 && drawn <= 3);   // ~200ms of 100ms cadence
+  TEST_ASSERT_TRUE(ov.lastDt >= 100);
 }
 
 int main(int, char**) {
   UNITY_BEGIN();
-  RUN_TEST(test_dual_role_overlay_suspends_and_restores);
+  RUN_TEST(test_dual_role_overlay_suspends_and_restores_surface);
   RUN_TEST(test_priority_arbitration);
   RUN_TEST(test_dedicated_surface_does_not_suspend);
+  RUN_TEST(test_null_surface_is_independent);
+  RUN_TEST(test_two_surfaces_arbitrate_independently);
   RUN_TEST(test_remove_active_overlay_resumes_app);
   RUN_TEST(test_swap_between_dual_role_overlays_keeps_suspended_no_restore);
+  RUN_TEST(test_app_loaded_under_claim_starts_suspended);
+  RUN_TEST(test_device_suspension_survives_overlay_cycle);
+  RUN_TEST(test_draw_paced_on_tick_cadence);
   UNITY_END();
   return 0;
 }


### PR DESCRIPTION
Driven by the first multi-overlay consumer (Hawthorn devices with a voice overlay and an agent-status overlay, sometimes on different screens — inanimate-tech/hawthorn-firmware#109). Two independent features.

## Overlay arbitration is per surface; the Overlay interface is reshaped (breaking)

- **Per-surface winners.** Overlays bound to the same surface contend by priority (ties: earlier registration); overlays on different surfaces are independent and can all show at once. Previously one global winner drew regardless of surface — a voice overlay on one screen wrongly suppressed a status overlay on another. `nullptr` surface is now defined: dedicated — contends with nothing, never suspends the app, no restore issued.
- **`priority()` virtual → `addOverlay(overlay, surface, priority)` parameter** (it's a property of the registration, not behavior).
- **`onActivate`/`onDeactivate` → `onAcquire`/`onRelease`** — an overlay is a *claim* on a surface; the names say so.
- **`Overlay::restore()` → `SystemDisplay::restoreContent()`.** Repainting "what's underneath" is surface knowledge, not overlay knowledge. Called by the arbiter when a surface's last claim releases — uniformly, suspended or not (previously restore only fired on the app-resume path, so non-suspending surfaces never restored). Handoffs to another overlay on the same surface issue no restore (no app-frame flash).
- **`onDraw(dtMs)` paced on the app-tick cadence** (10 FPS) instead of every `loop()` — the overlay takes over the suspended app's tick slot; consumers no longer hand-roll draw throttling. `onAcquire` is the immediate first paint.
- Fixes the two known-limitation comments: an app pushed under a held dual-role claim now loads suspended; a device-initiated `suspendApp()` survives an overlay cycle (arbiter only resumes suspensions it performed).

Migration: the m5stick-voice example is updated in this PR and shows the pattern; downstream Hawthorn is migrated and hardware-validated.

## Message interposition (new)

- **`onMessageFilter(cb)`** — single-slot pre-routing filter (return `false` to consume), running before deferral, reserved-type routing, and the user callback. Platform wrappers previously overwrote the Courier `onMessage` hook and re-implemented reserved-type routing by hand — which silently drifted as routing grew (the downstream copy predated `forget`, leaving it dead on those devices).
- **`deferAppLoads(bool)`** — stash incoming `app`/`shader` loads (last one wins, heap-serialized at measured size) during memory/CPU-sensitive windows (e.g. voice recording); clearing applies the stash immediately.
- **`injectMessage(...)`** — route a message through the full pipeline as if from a transport; for wrappers with their own receive path, and native tests.

## Testing

84/84 native unit tests: the overlay suite is rewritten for the new contract (10 cases incl. per-surface independence, dedicated surfaces, load-under-claim, device-suspension survival, tick pacing) and a new 9-case message-routing suite covers filter ordering, deferral last-wins, and inject. Hardware-validated downstream on fan-p1/m5sticks3 (shared-surface voice/status arbitration, dual-role app suspension, surface restore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)