### PR TITLE
fix(example): wait for the mic fill before returning samples

### DIFF
--- a/examples/m5stick-voice/device/src/M5MicDriver.h
+++ b/examples/m5stick-voice/device/src/M5MicDriver.h
@@ -2,19 +2,34 @@
 #include <M5Unified.h>
 #include <Resident.h>
 
+#include <cstring>
+
 // SystemMic backed by M5Unified's built-in microphone. 16 kHz mono int16.
 class M5MicDriver : public Resident::SystemMic {
 public:
   const char* name() const override { return "mic"; }
   void begin() override { M5.Mic.begin(); }  // idempotent; releases shared I2S
+  // M5.Mic.record() is asynchronous: it queues the destination buffer and
+  // returns while M5Unified's mic task fills it in the background. So the
+  // destination must be a buffer we own — handing over the caller's would let
+  // the task keep writing it after read() returns — and the copy out must wait
+  // for the fill to complete.
   int read(int16_t* buf, int maxSamples, int /*timeoutMs*/) override {
     if (!M5.Mic.isEnabled()) return 0;
-    if (M5.Mic.record(buf, maxSamples, SAMPLE_RATE)) return maxSamples;
-    return 0;
+    const int n = maxSamples < FRAME_SAMPLES ? maxSamples : FRAME_SAMPLES;
+    if (!M5.Mic.record(_staging, n, SAMPLE_RATE)) return 0;
+    // isRecording() is gated on a flag the mic task sets itself, so it reads 0
+    // until the task dequeues this request. Give it a tick to start before
+    // polling, or the wait falls through and we copy an unfilled buffer.
+    delay(1);
+    while (M5.Mic.isRecording()) { delay(1); }
+    memcpy(buf, _staging, n * sizeof(int16_t));
+    return n;
   }
   uint32_t sampleRate() const override { return SAMPLE_RATE; }
   int frameSamples() const override { return FRAME_SAMPLES; }
 private:
   static constexpr uint32_t SAMPLE_RATE = 16000;
   static constexpr int FRAME_SAMPLES = 512;
+  int16_t _staging[FRAME_SAMPLES];
 };


### PR DESCRIPTION
## Summary

`M5MicDriver::read()` returned `maxSamples` the instant `M5.Mic.record()` returned. `record()` is asynchronous — it queues the destination buffer and returns while M5Unified's mic task fills it in the background — so every read handed back a buffer that had not been written yet.

The destination was also the **caller's** buffer, so the mic task kept writing into memory the caller already considered its own, for as long as the fill took.

## Fix

Record into a buffer the driver owns, and copy out only once the fill has completed.

The completion poll needs a tick before it starts: `Mic_Class::isRecording()` is gated on `_is_recording`, a flag the mic task sets itself once it has dequeued work. Between `record()` queueing a request and the task starting it, `isRecording()` reads 0 with the fill still pending, so an immediate `while (isRecording())` falls straight through and copies an unfilled buffer.

## Notes

This keeps the example simple — one request in flight, waited to completion — which is correct but does leave the mic task's queue empty between reads. A driver doing continuous capture wants the queue kept non-empty instead, since M5Unified's mic task silently discards the partially consumed DMA chunk it is holding whenever it parks. The Hawthorn firmware's production `M5Microphone` does that with a three-buffer rotation over M5Unified's two-request lag.

Found while reviewing the same defect in that production driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)