### PR TITLE
fix(mic): derive slot completion from record(); state the SystemMic contract

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -599,9 +599,10 @@ Interface for a microphone the runtime can stream. Implement it in a driver and 
 ```cpp
 class MyMic : public Resident::SystemMic {
 public:
-    void begin() override { /* init capture hardware */ }
+    void begin() override { startCapture(); }   // pipeline runs from here on
     int read(int16_t* buf, int maxSamples, int timeoutMs) override {
-        return capture(buf, maxSamples);   // samples written; 0 on timeout / no data
+        // Copy out of a buffer *we* own; return what was actually ready.
+        return drainCaptured(buf, maxSamples, timeoutMs);
     }
     uint32_t sampleRate() const override { return 16000; }
     int frameSamples() const override { return 512; }   // natural read granularity
@@ -610,7 +611,7 @@ public:
 
 | Method | Default | Description |
 |--------|---------|-------------|
-| `read(int16_t* buf, int maxSamples, int timeoutMs)` | *(pure virtual)* | Fill up to `maxSamples` 16-bit mono samples; return the count written (0 on timeout) |
+| `read(int16_t* buf, int maxSamples, int timeoutMs)` | *(pure virtual)* | Drain up to `maxSamples` 16-bit mono samples; return the count actually written (0 if none ready) |
 | `sampleRate()` | *(pure virtual)* | Capture rate in Hz (e.g. `16000`) |
 | `frameSamples()` | *(pure virtual)* | Natural read chunk size |
 | `begin()` / `update()` | no-op | Standard `Driver` lifecycle |
@@ -625,6 +626,17 @@ sandbox.setMicStreamSink(fn);  // bool(const uint8_t* data, size_t len) — defa
 ```
 
 While streaming, each `Sandbox::loop()` reads up to `frameSamples()` (capped at an internal 512-sample buffer) and forwards the bytes to the sink — the default sink is `ws().sendBinary`. The pump adds **no framing or control frames**: any envelope (e.g. a `{"type":"..."}` start/stop text frame, or a format handshake) is a device concern, sent by your code around `startMicStream()` / `stopMicStream()`. Streaming is independent of app state — it continues while the app is suspended, and is a no-op when `cfg.systemMic` is unset.
+
+### Implementing `read()`
+
+Capture backends are usually asynchronous — DMA or a background task filling buffers while your code runs — and that makes `read()` easy to get subtly wrong. Every rule below has silently corrupted audio in a real driver:
+
+1. **Capture is `begin()`'s job, not `read()`'s.** Keep the pipeline running and its buffers queued from `begin()` onwards; `read()` only copies out what already landed. Don't start a capture inside `read()` and wait for that one buffer — a pipeline that holds a destination only while `read()` is in flight loses everything in between. Backends commonly discard the partial chunk they were holding whenever their queue runs dry, with no error and no counter, and every gap is an audible splice.
+2. **Never give capture hardware the caller's `buf`.** Record into memory the driver owns and copy out. An async backend keeps writing its destination after the call that queued it returned — so passing `buf` straight through is a background write into memory the caller already considers its own.
+3. **`timeoutMs == 0` means do not block.** Return what is ready this instant, `0` if that's nothing. The pump calls `read(buf, frameSamples(), 0)` from `Sandbox::loop()`, so blocking there stalls the whole sandbox — app ticks, transports, overlays and all. `timeoutMs > 0` is a ceiling to respect, not a duration to fill; never block unbounded.
+4. **Short reads are legal.** The return value is authoritative — never assume `maxSamples` were written. Returning `0` is routine and just means nothing has been captured yet.
+
+`examples/m5stick-voice/device/src/M5MicDriver.h` is a worked reference over an asynchronous backend (M5Unified), including how it derives buffer completion without polling.
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,11 +25,55 @@ Theme: channel-based message routing — an envelope `channel` field steers mess
 
 - **`Sandbox` now defaults a networked `Courier::Config::defaultTransport` to `"ws"` when unset and `host` is set** — under 0.6's "receive parallels send", an unset default transport meant `Client::onMessage` (and thus all channel routing) never fired on any real device; callers who set an explicit `defaultTransport` are unaffected.
 
+- **`m5stick-voice`'s `M5MicDriver` returned unfilled audio.** `M5.Mic.record()`
+  is asynchronous — it queues a destination buffer into M5Unified's request
+  queue and returns while the mic task fills it in the background — but the
+  driver returned `maxSamples` the instant it returned. Every read handed back
+  a buffer that had not been written yet, and because the destination was the
+  *caller's* buffer, the mic task went on writing memory the caller already
+  considered its own.
+
+  Rewritten as a three-buffer rotation that derives completion from `record()`
+  itself: M5Unified's queue holds exactly two requests and `record()` blocks
+  until its slot is free, so `record()` returning means the request queued two
+  calls earlier has completed — a guarantee, with nothing to poll. Queueing
+  before serving also keeps two requests outstanding at all times, which
+  matters: when its queue runs empty the mic task parks and silently discards
+  the partially consumed DMA chunk it was holding, splicing the audio. The old
+  one-buffer-per-read shape hit that on every read. The mic task is also now
+  pinned to core 1 at priority 18, which fixes a separate DMA-ring overrun
+  under TLS streaming load at M5Unified's default priority 2.
+
+  Note `isRecording()` is *not* a completion signal — it is gated on a flag the
+  mic task sets itself, so a freshly queued request reads back as "nothing
+  pending" and a wait on it falls straight through onto an unfilled buffer. It
+  answers queue occupancy, and is used only for that.
+
 ### Deprecations
 
 - **Un-channelled message routing** (no `channel` field) still works but now logs `[deprecated] un-channelled '<type>' message; sender should stamp channel` on every message. Stamp `channel:"app"`/`"system"`/a custom name instead.
 - **The `app_event` envelope** on the app channel still works but now logs `[deprecated] app_event wrapper; send channel:"app" with type=<event name>`.
 - **`Sandbox::onMessage` / `onMessageFilter`** now serve the legacy un-channelled path only (doc comments updated accordingly) — new code should use `onMessageWithChannel` / `handleAppMessage` / `handleSystemMessage`. Not yet `[[deprecated]]`-attributed: platform wrappers (e.g. Hawthorn's `HawthornRoomDevice`) still register the filter, and SDK examples may still use `onMessage`; attributes land when that shim is removed.
+
+### Internal
+
+- **`Resident::SystemMic::read()` now states its contract**, in
+  `ResidentSystemMic.h` and [api.md](api.md#implementing-read). The four rules
+  each correspond to a defect seen in a real driver: capture belongs in
+  `begin()` rather than `read()`; never hand capture hardware the caller's
+  buffer; `timeoutMs == 0` means *do not block* (the pump calls
+  `read(buf, frameSamples(), 0)` from `loop()`, so blocking stalls the whole
+  sandbox); and short reads — including `0` — are legal and routine.
+
+  Previously `timeoutMs == 0` was undefined, and independent implementations
+  had read it as "don't block", "block indefinitely" and "ignore the parameter
+  entirely". No runtime behaviour changed — the pump already passed `0` — but
+  that is now the documented, tested contract rather than an accident.
+
+- **Mic pump contract tests** (`test/unit/test/test_mic_stream/`) covering the
+  rules the pump is responsible for upholding: it reads with `timeoutMs == 0`,
+  forwards short reads verbatim rather than padding to `maxSamples`, and emits
+  nothing when a read returns `0`.
 
 ---
 

--- a/examples/m5stick-voice/device/src/M5MicDriver.h
+++ b/examples/m5stick-voice/device/src/M5MicDriver.h
@@ -2,19 +2,120 @@
 #include <M5Unified.h>
 #include <Resident.h>
 
+#include <cstring>
+
 // SystemMic backed by M5Unified's built-in microphone. 16 kHz mono int16.
+//
+// Reference implementation of Resident::SystemMic over an asynchronous capture
+// backend — the contract it is written against is in src/ResidentSystemMic.h.
+//
+// M5.Mic.record() does not record. It queues a destination buffer into
+// M5Unified's request queue and returns; the mic task fills the buffer in the
+// background. Two consequences drive this whole design:
+//
+//  * The queue holds exactly two requests, and record() blocks until the slot
+//    it wants to write is free. So record() returning tells you the request
+//    queued two calls earlier has completed — a guarantee, with nothing to
+//    poll. This driver rides it with a three-buffer rotation: queue the buffer
+//    just finished with, and the buffer whose completion that queueing waited
+//    on is the one to serve.
+//
+//    Do not use isRecording() as a completion signal. It is gated on a flag
+//    the mic task sets itself, so a freshly queued request still reads back as
+//    "nothing pending" and a wait on it falls straight through onto an
+//    unfilled buffer. It answers occupancy — "is there room in the queue" —
+//    which is all it is used for below.
+//
+//  * Queueing before serving keeps two requests outstanding at all times, so
+//    the mic task always has somewhere to write. That is load-bearing: when
+//    its queue runs empty the task parks, and on parking it throws away the
+//    partially consumed DMA chunk it was holding. No error, no counter, just a
+//    splice in the audio. A driver that queues a single buffer per read() runs
+//    the queue dry — and takes that hit — on every single read.
 class M5MicDriver : public Resident::SystemMic {
 public:
   const char* name() const override { return "mic"; }
-  void begin() override { M5.Mic.begin(); }  // idempotent; releases shared I2S
-  int read(int16_t* buf, int maxSamples, int /*timeoutMs*/) override {
-    if (!M5.Mic.isEnabled()) return 0;
-    if (M5.Mic.record(buf, maxSamples, SAMPLE_RATE)) return maxSamples;
-    return 0;
+
+  void begin() override {
+    auto cfg = M5.Mic.config();
+    cfg.sample_rate = SAMPLE_RATE;
+    // M5Unified's mic task defaults to priority 2, unpinned. This example
+    // records while streaming over TLS, and under that load the task runs late
+    // enough that the I2S DMA ring overruns and the audio tears. Core 0 already
+    // carries everything that would preempt it — WiFi at 23, esp_timer at 22,
+    // lwIP at 18, all pinned there by the Arduino sdkconfig — while core 1 runs
+    // only app tasks, so pinned there at 18 the mic task always wins promptly.
+    cfg.task_priority = 18;
+    cfg.task_pinned_core = 1;
+    M5.Mic.config(cfg);
+    _queued = 0;
+    _serveOff = 0;
+    M5.Mic.begin();  // idempotent; releases shared I2S
   }
+
+  int read(int16_t* buf, int maxSamples, int timeoutMs) override {
+    if (!M5.Mic.isEnabled() || maxSamples <= 0) return 0;
+    const unsigned long start = millis();
+
+    int served = 0;
+    while (served < maxSamples) {
+      // Only rotate on a slot boundary — mid-slot there are samples in hand.
+      if (_serveOff == 0 && !advance(start, timeoutMs)) break;
+      int n = maxSamples - served;
+      if (n > FRAME_SAMPLES - _serveOff) n = FRAME_SAMPLES - _serveOff;
+      memcpy(buf + served, _buf[_slot] + _serveOff, n * sizeof(int16_t));
+      served += n;
+      _serveOff += n;
+      if (_serveOff == FRAME_SAMPLES) _serveOff = 0;
+    }
+    return served;  // a short read (0 included) is a legal answer
+  }
+
   uint32_t sampleRate() const override { return SAMPLE_RATE; }
   int frameSamples() const override { return FRAME_SAMPLES; }
+
 private:
   static constexpr uint32_t SAMPLE_RATE = 16000;
   static constexpr int FRAME_SAMPLES = 512;
+  // Requests M5Unified's queue holds, and therefore the rotation's lag. The
+  // rotation needs one buffer more than that: two outstanding, one being
+  // served. Slot size sets the deadline for re-queueing — the queue only stays
+  // non-empty while read() comes back around within one slot duration, and at
+  // 512 samples (32 ms) the pump clears that comfortably.
+  static constexpr int QUEUE_DEPTH = 2;
+
+  // Hand the mic task its next destination, then pick up the buffer whose fill
+  // that queueing waited on. False if no full buffer came free within
+  // timeoutMs — immediately so when timeoutMs is 0.
+  bool advance(unsigned long start, int timeoutMs) {
+    while (_queued < QUEUE_DEPTH) {  // priming: queue without serving
+      if (!queueSlot()) return false;
+      _queued++;
+    }
+    // Wait for room here rather than inside record(), whose own spin is untimed
+    // and would sail straight past timeoutMs. isRecording() is occupancy only
+    // (2 = no room). It can under-report while the task is still starting,
+    // which at worst sends us into record() a moment early — harmless, because
+    // completion comes from record() returning, never from this poll.
+    while (M5.Mic.isRecording() >= (size_t)QUEUE_DEPTH) {
+      if (!M5.Mic.isRunning()) { _queued = 0; return false; }  // gone; re-prime
+      if (timeoutMs <= 0 || (long)(millis() - start) >= timeoutMs) return false;
+      delay(1);
+    }
+    if (!queueSlot()) { _queued = 0; return false; }
+    return true;
+  }
+
+  // Queue the current slot, then rotate on to the slot whose fill that
+  // queueing waited for — the one record() guarantees is complete.
+  bool queueSlot() {
+    if (!M5.Mic.record(_buf[_slot], FRAME_SAMPLES, SAMPLE_RATE)) return false;
+    _slot = (_slot + 1) % (QUEUE_DEPTH + 1);
+    return true;
+  }
+
+  int16_t _buf[QUEUE_DEPTH + 1][FRAME_SAMPLES];
+  int _slot = 0;      // buffer being served, and the next one to queue
+  int _serveOff = 0;  // samples of _buf[_slot] already handed out
+  int _queued = 0;    // outstanding requests (< QUEUE_DEPTH while priming)
 };

--- a/src/ResidentSystemMic.h
+++ b/src/ResidentSystemMic.h
@@ -11,8 +11,40 @@ namespace Resident {
 // 16-bit signed mono PCM. Hardware init runs in the Driver lifecycle (begin()).
 class SystemMic : public Driver {
 public:
-  // Read up to maxSamples samples into buf; returns samples written (0 on
-  // timeout / no data).
+  // Drain already-captured audio into buf; returns the number of samples
+  // written (0 if none are ready).
+  //
+  // Implementor contract. Capture backends are typically asynchronous — a DMA
+  // or task-driven pipeline filling buffers in the background — and every
+  // point below has silently corrupted audio in a real driver:
+  //
+  //  1. CAPTURE IS begin()'s JOB, NOT read()'s. Keep the pipeline running and
+  //     its buffers queued from begin() onwards; read() only copies out what
+  //     has already landed. Do not start a capture inside read() and wait for
+  //     that one buffer. A pipeline holding a destination only while read() is
+  //     in flight loses everything in between — backends commonly discard the
+  //     partial chunk they were holding whenever their queue runs dry, with no
+  //     error and no counter, and each gap is an audible splice.
+  //
+  //  2. NEVER GIVE CAPTURE HARDWARE THE CALLER'S BUFFER. Record into memory
+  //     the driver owns and copy out of it. An async backend goes on writing
+  //     its destination after the call that queued it has returned, so handing
+  //     it `buf` is a background write into memory the caller already
+  //     considers its own.
+  //
+  //  3. timeoutMs == 0 MEANS DO NOT BLOCK — return what is ready this instant,
+  //     0 if that is nothing. The runtime's mic pump calls
+  //     read(buf, frameSamples(), 0) from Sandbox::loop(), so blocking here
+  //     stalls the whole sandbox: app ticks, transports, overlays and all.
+  //     timeoutMs > 0 is a ceiling to respect, not a duration to fill. Never
+  //     block unbounded, whatever the timeout.
+  //
+  //  4. SHORT READS ARE LEGAL. The return value is authoritative — never
+  //     assume maxSamples were written. Returning 0 is routine and simply
+  //     means nothing has been captured yet.
+  //
+  // examples/m5stick-voice/device/src/M5MicDriver.h is a worked reference over
+  // an asynchronous backend.
   virtual int read(int16_t* buf, int maxSamples, int timeoutMs) = 0;
   virtual uint32_t sampleRate() const = 0;   // e.g. 16000
   virtual int frameSamples() const = 0;      // natural read granularity

--- a/test/unit/test/test_mic_stream/test_mic_stream.cpp
+++ b/test/unit/test/test_mic_stream/test_mic_stream.cpp
@@ -8,10 +8,17 @@ namespace {
 class FakeMic : public Resident::SystemMic {
 public:
   int frames = 512;
+  int returnSamples = -1;    // -1 = fill maxSamples; otherwise a short read
+  int lastTimeoutMs = -999;  // what the pump asked for
+  int calls = 0;
   const char* name() const override { return "mic"; }
-  int read(int16_t* b, int maxSamples, int) override {
-    for (int i = 0; i < maxSamples; i++) b[i] = (int16_t)i;
-    return maxSamples;
+  int read(int16_t* b, int maxSamples, int timeoutMs) override {
+    lastTimeoutMs = timeoutMs;
+    calls++;
+    int n = returnSamples < 0 ? maxSamples : returnSamples;
+    if (n > maxSamples) n = maxSamples;
+    for (int i = 0; i < n; i++) b[i] = (int16_t)i;
+    return n;
   }
   uint32_t sampleRate() const override { return 16000; }
   int frameSamples() const override { return frames; }
@@ -69,11 +76,45 @@ void test_frame_size_is_clamped(void) {
   TEST_ASSERT_EQUAL_UINT(512 * sizeof(int16_t), sends[0]);  // clamped to 512
 }
 
+// SystemMic contract: the pump runs inside loop(), so it must never ask the
+// driver to block. Drivers are documented against this (ResidentSystemMic.h);
+// if the pump ever starts passing a non-zero timeout, they are entitled to
+// stall the sandbox for it.
+void test_pump_never_asks_the_driver_to_block(void) {
+  sandbox->startMicStream();
+  runLoop(1);
+  TEST_ASSERT_EQUAL_INT(1, mic->calls);
+  TEST_ASSERT_EQUAL_INT(0, mic->lastTimeoutMs);
+}
+
+// Short reads are legal: forward exactly what read() returned, not what was
+// asked for. Sending maxSamples here would ship uninitialised buffer tail.
+void test_short_read_is_forwarded_verbatim(void) {
+  mic->returnSamples = 100;            // fewer than the 512 requested
+  sandbox->startMicStream();
+  runLoop(1);
+  TEST_ASSERT_EQUAL_INT(1, (int)sends.size());
+  TEST_ASSERT_EQUAL_UINT(100 * sizeof(int16_t), sends[0]);
+}
+
+// "Nothing captured yet" is routine, not an error — it must not produce an
+// empty frame on the wire.
+void test_empty_read_sends_nothing(void) {
+  mic->returnSamples = 0;
+  sandbox->startMicStream();
+  runLoop(3);
+  TEST_ASSERT_EQUAL_INT(3, mic->calls);      // still polled every loop
+  TEST_ASSERT_EQUAL_INT(0, (int)sends.size());
+}
+
 int main(int, char**) {
   UNITY_BEGIN();
   RUN_TEST(test_streaming_sends_frames_and_stops);
   RUN_TEST(test_streaming_works_while_suspended);
   RUN_TEST(test_frame_size_is_clamped);
+  RUN_TEST(test_pump_never_asks_the_driver_to_block);
+  RUN_TEST(test_short_read_is_forwarded_verbatim);
+  RUN_TEST(test_empty_read_sends_nothing);
   UNITY_END();
   return 0;
 }


### PR DESCRIPTION
Supersedes #20 — same defect, but the completion mechanism #20 used turns out to be the one [inanimate-tech/hawthorn-firmware#117](https://github.com/inanimate-tech/hawthorn-firmware/pull/117) rejected after on-device investigation. Also lifts the general rule out of the example and onto the interface, which is what stops the next driver author rediscovering it.

## The defect

`M5.Mic.record()` is asynchronous: it queues a destination buffer into M5Unified's request queue and returns while the mic task fills it in the background. `M5MicDriver::read()` returned `maxSamples` the instant it returned, so every read handed back a buffer that had not been written yet — and because the destination was the **caller's** buffer, the mic task went on writing memory the caller already considered its own.

## Why not poll `isRecording()`

Verified against M5Unified `master`, `src/utility/Mic_Class.{hpp,cpp}`:

```cpp
// Mic_Class.hpp:117
size_t isRecording(void) const { return _is_recording ? ((bool)_rec_info[0].length) + ((bool)_rec_info[1].length) : 0; }
```

`_is_recording` is set at `Mic_Class.cpp:596`, **inside the mic task**, after it dequeues. So between `record()` queueing and the task waking, this reads 0 with the fill still pending — a wait on it falls straight through onto an unfilled buffer. Priming it with a `delay(1)` is a bet on the task winning the CPU within one tick, not a guarantee. `isRecording()` answers queue occupancy (its own docs: `2 = no room in the queue`), and that is all it is used for here.

## What it does instead

`_rec_raw()` at `Mic_Class.cpp:777` blocks until its slot frees:

```cpp
while (_rec_info[_rec_flip].length) { xSemaphoreTake(_task_semaphore, 1); }
```

The queue holds exactly two requests, so **`record()` returning means the request queued two calls earlier has completed** — a guarantee, with nothing to poll. `read()` rides it with a three-buffer rotation: queue the buffer just finished serving, then serve the buffer whose completion that queueing waited on.

Queueing before serving keeps two requests outstanding at all times, which is load-bearing. When its queue runs empty the mic task parks, and on parking (`Mic_Class.cpp:587-590`) does `src_idx = ~0u; src_len = 0` — discarding the partially consumed DMA chunk. No error, no counter, just a splice. **The old one-buffer-per-read shape ran the queue dry on every single read**, so the example was demonstrating exactly the audio defect #117 exists to eliminate.

The mic task is also pinned to core 1 at priority 18. This example records while streaming over TLS, and #117 measured a DMA-ring overrun under that load at M5Unified's default priority 2.

## The interface half

The trap is not M5-specific, so the rule that would have caught it now lives on the interface rather than in one example. `timeoutMs == 0` was previously **undefined**, and three independent implementations had read it three incompatible ways:

| Site | `timeoutMs == 0` meant |
|---|---|
| `Sandbox::updateMicStream()` — `read(_micBuf, want, 0)` every `loop()` | "non-blocking, give me what's ready" |
| `M5MicDriver` before this PR | ignored the parameter; blocked ~32 ms per call |
| hawthorn-firmware `M5Microphone::advance()` — `if (timeoutMs > 0 && ...)` | **block indefinitely** |

`ResidentSystemMic.h` and `docs/api.md` now state four rules, each matching a defect seen in a real driver: capture belongs in `begin()` not `read()`; never hand capture hardware the caller's buffer; `timeoutMs == 0` means do not block; short reads (`0` included) are legal.

**No runtime behaviour changes** — the pump already passed `0`. `src/` is documentation-only; the contract was chosen to match what the runtime already does, so this is a zero-risk change to the library itself.

## Tests

Three pump contract tests in `test/unit/test/test_mic_stream/`: reads with `timeoutMs == 0`, forwards short reads verbatim rather than padding to `maxSamples`, and emits nothing when a read returns `0`.

`./tools/run-tests.py all` — cppcheck clean, 88/88 unit cases, all example envs build including both `m5stick-voice` boards (`m5stick`, `m5sticks3`).

Not hardware-validated by me; #117 carries the on-device measurements for the same rotation.

## Note for #117

`M5Microphone::advance()` treats `timeoutMs <= 0` as "wait as long as the mic task runs". Under the contract above that inverts the intended meaning, so if `M5Microphone` is ever adapted onto `Resident::SystemMic`, the pump's `0` would block the sandbox loop indefinitely. Worth reconciling when the submodule pointer moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)