### PR TITLE
arc: reactive framework spike for generative device UI + live m5stick demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ examples/*/dependencies.lock
 # PlatformIO test build artifacts
 test/unit/.pio/
 
+# Node dependencies (per-example server projects)
+node_modules/
+
 # Python bytecode (from tools/run-tests.py and friends)
 __pycache__/
 

--- a/examples/m5stick-arc/README.md
+++ b/examples/m5stick-arc/README.md
@@ -87,6 +87,40 @@ working — a turn or a remix — the arc runtime itself pulses three amber
 dots in the bottom-right corner, on top of whatever waiting state the
 current view has authored; that's framework chrome, not app code.
 
+## Voice (push-to-talk)
+
+**Hold the front button and speak; release to send.** The driver's
+long-press detector doubles as tap-suppression, so holding to talk never
+registers as a choice-B tap. While held, the firmware brackets the mic
+pump's raw 16 kHz PCM with `voice start/end` system-channel envelopes and
+injects `ptt` events so the running app can show its listening state.
+
+Server-side, the take is transcribed with Workers AI whisper
+(`@cf/openai/whisper-large-v3-turbo`, via the AI Gateway binding — still
+no secrets in the worker), and the transcript is immediately sent back as
+a `heard` event — the app shows what the device heard before anything is
+done about it.
+
+Then a model decides what the words *mean* — nothing is hardcoded. The
+router is given the device's current Lua program, its live store, and the
+utterance, and returns one of:
+
+- **intent** — "I should take that lantern" ≈ choice A → it injects
+  `choose_a` onto the normal bus, indistinguishable from a button press;
+- **turn** — "I want to climb the tree and look at the moon" fits no
+  intent → the narrator weaves it into the next beat, delivered as an
+  `arc:hydrate`;
+- **ignore** — noise.
+
+The generation needed zero framework changes for any of this: `ptt` and
+`heard` are ordinary intents, and voice-routed actions reuse the existing
+reply/hydrate paths.
+
+Voice can be exercised without hardware: synthesize a take
+(`say -o take.wav --file-format=WAVE --data-format=LEI16@16000 "..."`)
+and stream it over a plain `/devices/<id>` WebSocket between `voice`
+start/end envelopes, watching the result on the monitor socket.
+
 `POST /devices/<id>/arc/remix` runs the same remix as the shake but returns
 vet/inference diagnostics in the response — useful when prompt-tuning the
 view writer.

--- a/examples/m5stick-arc/README.md
+++ b/examples/m5stick-arc/README.md
@@ -1,0 +1,99 @@
+# m5stick-arc
+
+A live demo of **arc** (see `spikes/arc/DESIGN.md`), the reactive framework
+for generative device UI, on an M5Stick: a choose-your-own-adventure whose
+next scene is written by a model, on the fly, through Cloudflare AI Gateway.
+
+The three loops, live:
+
+- **Reflex** (on the stick, <150ms): button press → beep + waiting
+  indicator, instantly, from the shipped Lua generation. Tilting the stick
+  sways the lantern glow at 10 FPS with zero network traffic — but the tilt
+  value rides along in the next ask, so how you hold the lantern quietly
+  shapes the story.
+- **Response** (1–10s): the press escalates as an `arc:ask` event; the
+  server answers it with a fast model (`claude-haiku-4-5`) through AI
+  Gateway and the scene updates on the reply. A 9s timeout falls back to
+  shipped microcopy.
+- **Revision** (the generative-UI part): **shake the stick** (or the
+  viewer's Remix button) and a stronger model (`claude-sonnet-5`) writes a
+  brand-new Lua *view function* — layout, palette, decoration, motion, and
+  its own waiting-state microcopy. The server syntax-checks it (luaparse +
+  a banned-construct vet), splices it into the generation, pushes it to the
+  device, and re-hydrates the story state so play continues where it left
+  off. Every shake produces a different UI, authored by a model at runtime.
+  A rejected or failed remix degrades to an `arc:reply` and the current
+  look survives; a view that errors at runtime is caught by the arc
+  renderer's pcall and logged, never crashing the app.
+
+## Layout
+
+```
+app/arc.lua        the arc L1 runtime (copy of spikes/arc/arc.lua)
+app/adventure.lua  the generation (copy of spikes/arc/apps/adventure.lua)
+device/            PlatformIO firmware (same drivers as m5stick-demo)
+server/            Cloudflare Worker: ArcAgent relay + inference + viewer
+```
+
+## Server
+
+```bash
+cd server
+npm install
+CLOUDFLARE_ACCOUNT_ID=<your account id> npx wrangler deploy
+```
+
+The worker uses the AI Gateway named by the `CLOUDFLARE_AIG_ID` var (BYOK:
+the gateway's secrets store holds the Anthropic key, the worker holds no
+model secret). Asks are answered by a fast model (`claude-haiku-4-5`);
+replies are budgeted to the device's 256-byte event buffer.
+
+## Device
+
+Build with the deployed hostname (or edit `RESIDENT_HOST` in
+`device/src/main.cpp`):
+
+```bash
+cd device
+PLATFORMIO_BUILD_FLAGS='-DARC_HOST=\"<host>\"' \
+  pio run -e m5sticks3 -t upload   # or -e m5stick for the M5StickC Plus2
+```
+
+Note `src/le_roots.h`: workers.dev serves a Let's Encrypt chain, but this
+Arduino build has no IDF cert bundle and Courier's embedded fallback root
+(GTS Root R4) only covers Cloudflare universal SSL — so `main.cpp` pins the
+ISRG roots via `onConfigureNetwork`. Skip this if you front the worker with
+a custom domain on Cloudflare.
+
+## Run it
+
+Open `https://<host>/devices/<deviceId>` in a browser — the live viewer
+shows the device mirror (`arc:state`), the full message stream in both
+directions, and per-ask latency. Buttons:
+
+- **Push adventure app** — ship a fresh generation (default look, story
+  reset) to the stick.
+- **Choose A / B / Remix** — inject the same intents the physical buttons
+  and the shake gesture produce (in arc, the agent is just another input
+  device; the handlers can't tell).
+- **Probe** — ask the device to publish its mirror.
+
+Or from the stick itself: held landscape, the **top-edge side button**
+picks choice A (the top option) and the **front face button** picks B;
+**shake** remixes the look; two minutes of quiet publishes a `bored`
+intent (visible in the viewer — a fuller agent would respond by
+regenerating the app into something else entirely). Whenever the agent is
+working — a turn or a remix — the arc runtime itself pulses three amber
+dots in the bottom-right corner, on top of whatever waiting state the
+current view has authored; that's framework chrome, not app code.
+
+`POST /devices/<id>/arc/remix` runs the same remix as the shake but returns
+vet/inference diagnostics in the response — useful when prompt-tuning the
+view writer.
+
+Findings that fed back into arc/Resident from getting this live, kept in
+`spikes/arc/DESIGN.md` §9: the device's `events.send` serializer does not
+escape quotes (arc sanitizes strings before publishing); replies must fit
+the 256-byte incoming event buffer (the server trims to fit, at word
+boundaries); a worker deploy resets the Durable Object and drops the
+device WebSocket mid-session.

--- a/examples/m5stick-arc/app/adventure.lua
+++ b/examples/m5stick-arc/app/adventure.lua
@@ -1,0 +1,99 @@
+-- generation: adventure (live-demo edition)
+-- Logic layer: store, recognizers, handlers, timelines — stable across looks.
+-- The LOOK is swappable: arc.view(...) may be re-registered by a model-written
+-- chunk the server appends after this file (shake = "remix"). Both this
+-- default view and remixed views read the same globals:
+--
+--   S       the store: S.text, S.a, S.b, S.scene
+--   TILT    smoothed accelerometer: TILT.x, TILT.y (≈ -1..1) — the lantern
+--
+-- Local vs remote, on purpose: tilt sways the lantern glow at 10 FPS with no
+-- network involvement; button presses beep instantly (reflex) then escalate
+-- as asks (response); shake regenerates the whole look (revision).
+
+S = arc.store{
+  scene = 1,
+  text  = "You wake in a moonlit orchard. A lantern glows by the gate, and something rustles in the long grass.",
+  a     = "Take the lantern",
+  b     = "Follow the rustle",
+}
+
+TILT = { x = 0, y = 0 }
+arc.every(100, function()
+  local ax, ay = imu.accel()
+  TILT.x = TILT.x * 0.7 + ax * 0.3
+  TILT.y = TILT.y * 0.7 + ay * 0.3
+end)
+
+-- Held landscape, the top-edge side button (index 1) lines up with the top
+-- choice (A); the front face button (index 0) is B.
+arc.tap(1, "choose_a")
+arc.tap(0, "choose_b")
+arc.shake(2.0, "remix")
+arc.idle(120000, "bored")
+
+local function turn(choice)
+  buzzer.beep(660, 30)                       -- reflex acknowledgment
+  local r = arc.ask("turn", {
+    choice = choice,
+    scene  = S.scene,
+    tilt   = math.floor(TILT.x * 100) / 100, -- how the lantern is held
+  }, {
+    timeout_ms = 9000,
+    fallback = { text = "The mist thickens and the moment passes. The orchard waits for you to choose again." },
+  })
+  if r.text then S.text = r.text end
+  if r.a then S.a = r.a end
+  if r.b then S.b = r.b end
+  if r.scene then S.scene = r.scene end
+  arc.play{ {520, 40}, {0, 20}, {780, 60} }  -- page-turn chime on arrival
+end
+
+arc.on("choose_a", function() turn("a") end)
+arc.on("choose_b", function() turn("b") end)
+
+arc.on("remix", function()
+  arc.play{ {300, 50}, {0, 30}, {300, 50} }
+  -- If the server accepts, it replies by REPLACING this whole generation
+  -- (new model-written view, story re-hydrated) — this ask usually dies with
+  -- the app swap. The reply/fallback path only lands if the remix failed.
+  arc.ask("remix", { scene = S.scene }, {
+    timeout_ms = 20000,
+    fallback = { note = "The world holds its shape." },
+  })
+end)
+
+-- "bored" has no local handler: published upstream for the revision loop.
+
+-- The default look. A remix chunk appended after this file re-registers
+-- arc.view and this function simply stops being called.
+arc.view(function()
+  local glow = math.floor(120 + TILT.x * 90)
+  -- arc.pending returns the ask's payload, so the wait can CONFIRM the
+  -- choice: the picked option stays lit, the other dims. Local echo — the
+  -- reassurance runs on-device while the slow loop thinks.
+  local p = arc.pending("turn")
+  return ui.col{ pad = 6, gap = 4,
+    ui.canvas{ w = 228, h = 10, draw = function(x, y)
+      screen.fill_rect(x, y + 8, 228, 1, 60, 50, 20)            -- horizon
+      screen.fill_rect(glow - 8, y + 2, 16, 6, 255, 190, 60)    -- lantern glow
+      screen.fill_rect(glow - 2, y, 4, 8, 255, 240, 180)        -- flame
+    end },
+    ui.text{ text = S.text, size = 1, w = 228, color = "white" },
+    p and ui.col{ gap = 2,
+        ui.label{ text = "A) " .. S.a, size = 1,
+                  color = (p.choice == "a") and "amber" or "dim" },
+        ui.label{ text = "B) " .. S.b, size = 1,
+                  color = (p.choice == "b") and "amber" or "dim" },
+        ui.label{ text = "the story stirs" .. string.rep(".", arc.dots(3)),
+                  size = 1, color = "amber" },
+      }
+      or ui.col{ gap = 2,
+           ui.label{ text = "A) " .. S.a, size = 1, color = "cyan" },
+           ui.label{ text = "B) " .. S.b, size = 1, color = "cyan" },
+         },
+    arc.pending("remix")
+      and ui.label{ text = "reimagining the world...", size = 1, color = "magenta" }
+      or false,
+  }
+end)

--- a/examples/m5stick-arc/app/adventure.lua
+++ b/examples/m5stick-arc/app/adventure.lua
@@ -63,6 +63,37 @@ arc.on("remix", function()
   })
 end)
 
+-- Voice. Hold the front button to talk: the firmware injects "ptt" events
+-- around the mic stream, and the server sends "heard" with the transcript
+-- once whisper has run — local confirmation of what the device heard. What
+-- the utterance MEANS is decided server-side by a model reading this very
+-- program; if it maps to an intent (choose_a/choose_b/remix) that intent
+-- arrives on the bus like any button press, and if it's free-form story
+-- input the next beat arrives as an arc:hydrate.
+S.voice = ""   -- "" | listening prompt | ellipsis | quoted transcript
+
+local function clear_voice_later(was, ms)
+  arc.after(ms, function()
+    if S.voice == was then S.voice = "" end
+  end)
+end
+
+arc.on("ptt", function(p)
+  if p.state == "on" then
+    buzzer.beep(980, 30)
+    S.voice = "listening..."
+  else
+    S.voice = "..."
+    clear_voice_later("...", 8000)   -- transcript never came; stand down
+  end
+end)
+
+arc.on("heard", function(p)
+  local t = p.text or ""
+  if t == "" then S.voice = "(couldn't hear)" else S.voice = '"' .. t .. '"' end
+  clear_voice_later(S.voice, 6000)
+end)
+
 -- "bored" has no local handler: published upstream for the revision loop.
 
 -- The default look. A remix chunk appended after this file re-registers
@@ -94,6 +125,9 @@ arc.view(function()
          },
     arc.pending("remix")
       and ui.label{ text = "reimagining the world...", size = 1, color = "magenta" }
+      or false,
+    (S.voice ~= "")
+      and ui.text{ text = S.voice, size = 1, w = 228, color = "green" }
       or false,
   }
 end)

--- a/examples/m5stick-arc/app/arc.lua
+++ b/examples/m5stick-arc/app/arc.lua
@@ -1,0 +1,530 @@
+-- arc — L1 runtime for generative device UI on the Resident sandbox.
+-- Spike / toy implementation. See DESIGN.md.
+--
+-- This file is concatenated ahead of a generation (the agent- or
+-- human-written app) and pushed as one Resident app. It defines the
+-- sandbox lifecycle globals (init / on_tick / on_event) itself;
+-- generations only call arc.* / ui.* and never define those.
+--
+-- Written against Lua 5.1+ (device interpreter and host sim both work).
+
+arc = arc or {}   -- the server may prepend `arc = { _gen = "<id>" }`
+ui  = {}
+
+arc._gen = arc._gen or "dev"
+
+-- ---------------------------------------------------------------------------
+-- internals
+
+local now = 0                  -- ctx.time_ms, refreshed on every callback
+local dirty = true             -- view needs re-render
+local store_raw = nil          -- backing table of the store proxy
+local store_dirty = false      -- mirror needs (throttled) publish
+local view_fn = nil
+local handlers = {}            -- intent name -> fn
+local running = {}             -- coroutine -> true while it is a live handler
+local timers = {}              -- list of {at, every, fn, last, dead}
+local taps = {}                -- button index -> intent name
+local shakes = {}              -- list of {g, name, until_ms}
+local idles = {}               -- list of {ms, name, fired}
+local last_activity = 0
+local pending = {}             -- ask id -> {co, name, deadline, fallback}
+local next_ask_id = 1
+local outbox = {}              -- list of {name, data, keep}
+local OUTBOX_MAX = 16
+local STATE_MIN_INTERVAL = 5000
+local last_state_sent = -STATE_MIN_INTERVAL
+
+local unpack_ = table.unpack or unpack
+
+local function flatten(t)
+  -- events.send accepts flat string/number values only; booleans -> 1/0.
+  -- Its serializer does NOT escape JSON specials, so a quote or backslash in
+  -- a value corrupts the payload (it arrives as {}) — sanitize them away.
+  local out = {}
+  if t then
+    for k, v in pairs(t) do
+      local tv = type(v)
+      if tv == "string" then out[k] = v:gsub('"', "'"):gsub("\\", "/")
+      elseif tv == "number" then out[k] = v
+      elseif tv == "boolean" then out[k] = v and 1 or 0 end
+    end
+  end
+  return out
+end
+
+local function merged(base, extra)
+  local out = flatten(extra)
+  for k, v in pairs(base) do out[k] = v end   -- reserved keys win
+  return out
+end
+
+local function outbox_push(name, data, keep)
+  if #outbox >= OUTBOX_MAX then
+    for i, m in ipairs(outbox) do            -- drop oldest droppable, never asks
+      if not m.keep then table.remove(outbox, i); break end
+    end
+    if #outbox >= OUTBOX_MAX then return end -- all keepers: drop this one
+  end
+  outbox[#outbox + 1] = { name = name, data = data, keep = keep }
+end
+
+local function outbox_drain()
+  while outbox[1] do
+    if events.send(outbox[1].name, outbox[1].data) then
+      table.remove(outbox, 1)
+    else
+      return  -- rate-limited or offline; retry next tick
+    end
+  end
+end
+
+local function resume(co, ...)
+  local ok, err = coroutine.resume(co, ...)
+  if not ok then log.error("arc handler: " .. tostring(err)) end
+  if coroutine.status(co) == "dead" then running[co] = nil end
+  dirty = true
+end
+
+-- ---------------------------------------------------------------------------
+-- store
+
+function arc.store(defaults)
+  if store_raw then error("arc.store: only one store per app", 2) end
+  store_raw = {}
+  for k, v in pairs(defaults or {}) do store_raw[k] = v end
+  arc._raw_store = store_raw   -- debug/sim access
+  return setmetatable({}, {
+    __index = store_raw,
+    __newindex = function(_, k, v)
+      if store_raw[k] ~= v then
+        store_raw[k] = v
+        dirty = true
+        store_dirty = true
+      end
+    end,
+  })
+end
+
+-- ---------------------------------------------------------------------------
+-- intent bus
+
+function arc.on(name, fn) handlers[name] = fn end
+
+local function dispatch(name, payload, is_activity)
+  if is_activity then
+    last_activity = now
+    for _, w in ipairs(idles) do w.fired = false end
+  end
+  outbox_push("arc:intent", merged({ name = name }, payload))
+  local fn = handlers[name]
+  if fn then
+    local co = coroutine.create(fn)
+    running[co] = true
+    resume(co, payload or {})
+  end
+  dirty = true
+end
+
+function arc.intent(name, payload) dispatch(name, payload, true) end
+
+-- recognizers -----------------------------------------------------------------
+
+function arc.tap(index, name) taps[index] = name end
+
+function arc.shake(g, name)
+  shakes[#shakes + 1] = { g = g, name = name, until_ms = 0 }
+end
+
+function arc.idle(ms, name)
+  idles[#idles + 1] = { ms = ms, name = name, fired = false }
+end
+
+-- asks ------------------------------------------------------------------------
+
+function arc.ask(name, payload, opts)
+  opts = opts or {}
+  local co = coroutine.running()
+  if not co or not running[co] then
+    error("arc.ask must be called inside an intent handler", 2)
+  end
+  local id = next_ask_id
+  next_ask_id = next_ask_id + 1
+  pending[id] = {
+    co = co, name = name,
+    deadline = now + (opts.timeout_ms or 10000),
+    fallback = opts.fallback,
+    payload = payload,
+  }
+  outbox_push("arc:ask",
+    merged({ ask = name, id = id, gen = arc._gen }, payload), true)
+  dirty = true                       -- render the pending state immediately
+  return coroutine.yield()
+end
+
+-- Returns the pending ask's PAYLOAD (truthy table) rather than a bare true,
+-- so the view can echo what was asked during the wait — e.g. highlight the
+-- choice the user just made. Falsy when nothing is pending.
+function arc.pending(name)
+  for _, p in pairs(pending) do
+    if name == nil or p.name == name then return p.payload or true end
+  end
+  return false
+end
+
+-- timelines -------------------------------------------------------------------
+
+function arc.every(ms, fn)
+  local t = { at = now + ms, every = ms, fn = fn, last = now }
+  timers[#timers + 1] = t
+  return t
+end
+
+function arc.after(ms, fn)
+  local t = { at = now + ms, fn = fn, last = now }
+  timers[#timers + 1] = t
+  return t
+end
+
+function arc.cancel(t) if t then t.dead = true end end
+
+function arc.tween(o)
+  local from, to, ms = o.from or 0, o.to or 1, o.ms or 300
+  local ease, t0 = o.ease or "linear", now
+  return function()
+    local p = ms > 0 and (now - t0) / ms or 1
+    if p < 0 then p = 0 elseif p > 1 then p = 1 end
+    if ease == "in" then p = p * p
+    elseif ease == "out" then p = 1 - (1 - p) * (1 - p) end
+    return from + (to - from) * p
+  end
+end
+
+function arc.play(notes)
+  local at = 0
+  for _, n in ipairs(notes) do
+    local freq, ms = n[1], n[2]
+    if freq > 0 then
+      if at == 0 then buzzer.beep(freq, ms)
+      else arc.after(at, function() buzzer.beep(freq, ms) end) end
+    end
+    at = at + ms
+  end
+end
+
+-- misc ------------------------------------------------------------------------
+
+function arc.publish(name, payload) outbox_push(name, flatten(payload)) end
+
+function arc.view(fn) view_fn = fn end
+
+function arc.fmt_ms(ms)
+  local m = math.floor(ms / 60000)
+  local s = math.floor(ms / 1000) % 60
+  local t = math.floor(ms / 100) % 10
+  return string.format("%02d:%02d.%d", m, s, t)
+end
+
+function arc.dots(n) return 1 + math.floor(now / 400) % n end
+
+-- ---------------------------------------------------------------------------
+-- ui: widgets are plain tables; the renderer below is deliberately dumb
+
+local PALETTE = {
+  white = {255,255,255}, black = {0,0,0},     gray = {160,160,160},
+  dim   = {90,90,90},    red   = {255,80,80}, green = {80,255,120},
+  blue  = {80,160,255},  amber = {255,190,60}, cyan = {80,220,255},
+  magenta = {255,80,255},
+}
+
+local function rgbc(c)
+  if type(c) == "string" then c = PALETTE[c] end
+  c = c or PALETTE.white
+  return c[1], c[2], c[3]
+end
+
+local function widget(kind)
+  return function(t) t.kind = kind; return t end
+end
+
+ui.col    = widget("col")
+ui.row    = widget("row")
+ui.label  = widget("label")
+ui.text   = widget("text")
+ui.rect   = widget("rect")
+ui.bar    = widget("bar")
+ui.space  = widget("space")
+ui.qr     = widget("qr")
+ui.canvas = widget("canvas")
+
+local CHAR_W, CHAR_H = 6, 8    -- base font cell; multiplied by size
+
+local function wrap_text(str, size, w)
+  local maxc = math.max(1, math.floor(w / (CHAR_W * size)))
+  local lines, line = {}, ""
+  for w in tostring(str):gmatch("%S+") do
+    local word = w
+    while #word > maxc do                      -- hard-split oversized words
+      if #line > 0 then lines[#lines + 1] = line; line = "" end
+      lines[#lines + 1] = word:sub(1, maxc)
+      word = word:sub(maxc + 1)
+    end
+    if line == "" then line = word
+    elseif #line + 1 + #word <= maxc then line = line .. " " .. word
+    else lines[#lines + 1] = line; line = word end
+  end
+  if #line > 0 then lines[#lines + 1] = line end
+  if #lines == 0 then lines[1] = "" end
+  return lines
+end
+
+local measure
+
+local function measure_children(w)
+  local ws, hs, kids = {}, {}, {}
+  for _, child in ipairs(w) do
+    if type(child) == "table" then             -- skip false/holes from conds
+      local cw, ch = measure(child)
+      kids[#kids + 1] = child
+      ws[#ws + 1] = cw
+      hs[#hs + 1] = ch
+    end
+  end
+  return kids, ws, hs
+end
+
+measure = function(w)
+  local k = w.kind
+  if k == "label" then
+    local size = w.size or 2
+    return #tostring(w.text or "") * CHAR_W * size, CHAR_H * size
+  elseif k == "text" then
+    local size = w.size or 2
+    w._lines = wrap_text(w.text or "", size, w.w or 228)
+    local widest = 0
+    for _, l in ipairs(w._lines) do widest = math.max(widest, #l) end
+    return widest * CHAR_W * size, #w._lines * CHAR_H * size
+  elseif k == "rect" or k == "canvas" or k == "space" or k == "bar" then
+    return w.w or 0, w.h or 0
+  elseif k == "qr" then
+    return 33 * (w.scale or 4), 33 * (w.scale or 4)
+  elseif k == "col" or k == "row" then
+    local pad, gap = w.pad or 0, w.gap or 0
+    local kids, ws, hs = measure_children(w)
+    w._kids, w._ws, w._hs = kids, ws, hs
+    local main, cross = 0, 0
+    for i = 1, #kids do
+      if k == "col" then
+        main = main + hs[i]; cross = math.max(cross, ws[i])
+      else
+        main = main + ws[i]; cross = math.max(cross, hs[i])
+      end
+    end
+    if #kids > 0 then main = main + gap * (#kids - 1) end
+    if k == "col" then return cross + 2 * pad, main + 2 * pad
+    else return main + 2 * pad, cross + 2 * pad end
+  end
+  return 0, 0
+end
+
+local draw
+
+local function draw_stack(w, x, y)
+  local pad, gap = w.pad or 0, w.gap or 0
+  local ww, wh = measure(w)  -- refresh _kids/_ws/_hs (cheap, tree is tiny)
+  local cx, cy = x + pad, y + pad
+  for i, child in ipairs(w._kids) do
+    local dx, dy = cx, cy
+    if w.align == "center" then
+      if w.kind == "col" then dx = x + math.floor((ww - w._ws[i]) / 2)
+      else dy = y + math.floor((wh - w._hs[i]) / 2) end
+    end
+    draw(child, dx, dy)
+    if w.kind == "col" then cy = cy + w._hs[i] + gap
+    else cx = cx + w._ws[i] + gap end
+  end
+end
+
+draw = function(w, x, y)
+  x, y = math.floor(x), math.floor(y)
+  local k = w.kind
+  if k == "label" then
+    local r, g, b = rgbc(w.color)
+    screen.text(x, y, tostring(w.text or ""), w.size or 2, r, g, b)
+  elseif k == "text" then
+    local size = w.size or 2
+    local r, g, b = rgbc(w.color)
+    for i, line in ipairs(w._lines or wrap_text(w.text or "", size, w.w or 228)) do
+      screen.text(x, y + (i - 1) * CHAR_H * size, line, size, r, g, b)
+    end
+  elseif k == "rect" then
+    local r, g, b = rgbc(w.color)
+    if w.fill == false then screen.rect(x, y, w.w, w.h, r, g, b)
+    else screen.fill_rect(x, y, w.w, w.h, r, g, b) end
+  elseif k == "bar" then
+    local r, g, b = rgbc(w.color)
+    local v = math.max(0, math.min(1, w.value or 0))
+    screen.rect(x, y, w.w, w.h, r, g, b)
+    local fw = math.floor((w.w - 4) * v)
+    if fw > 0 then screen.fill_rect(x + 2, y + 2, fw, w.h - 4, r, g, b) end
+  elseif k == "qr" then
+    screen.qr(x, y, tostring(w.data or ""), w.scale or 4)
+  elseif k == "canvas" then
+    if w.draw then w.draw(x, y) end
+  elseif k == "col" or k == "row" then
+    draw_stack(w, x, y)
+  end
+end
+
+local activity_on = true
+function arc.activity(on) activity_on = (on ~= false) end
+
+-- System chrome: whenever an ask is in flight, the runtime itself draws a
+-- small pulsing indicator (three amber dots, bottom-right). Views can add
+-- richer treatments on top, but silently running inference is not the
+-- default — an app must opt out (arc.activity(false)) to hide it.
+local function draw_activity()
+  if not activity_on or next(pending) == nil then return end
+  local w, h = screen.width(), screen.height()
+  local lit = 1 + math.floor(now / 300) % 3
+  for i = 1, 3 do
+    local x = w - 24 + (i - 1) * 7
+    if i == lit then screen.fill_rect(x, h - 7, 4, 4, 255, 190, 60)
+    else screen.fill_rect(x, h - 6, 4, 2, 90, 70, 25) end
+  end
+end
+
+local function render()
+  if not view_fn then return end
+  -- the whole pipeline is protected: a bad view (e.g. a model-written one)
+  -- must never take the app down — it logs and leaves the last frame up
+  local ok, err = pcall(function()
+    local tree = view_fn()
+    arc._last_tree = tree      -- debug/sim access; also the mirror's view
+    screen.clear()
+    draw(tree, 0, 0)
+    draw_activity()
+    screen.flip()
+  end)
+  if not ok then log.error("arc view: " .. tostring(err)); return end
+  dirty = false
+end
+
+-- ---------------------------------------------------------------------------
+-- mirror
+
+local function send_state(force)
+  if not store_raw then return end
+  if not force and now - last_state_sent < STATE_MIN_INTERVAL then return end
+  -- events.send serializes into a bounded 256-byte buffer; trim long strings
+  -- so the mirror arrives intact rather than truncated mid-JSON
+  local snap = merged({ gen = arc._gen }, store_raw)
+  for k, v in pairs(snap) do
+    if type(v) == "string" and #v > 40 then snap[k] = v:sub(1, 37) .. "..." end
+  end
+  outbox_push("arc:state", snap)
+  last_state_sent = now
+  store_dirty = false
+end
+
+-- ---------------------------------------------------------------------------
+-- sandbox lifecycle (the only place these globals are defined)
+
+function init(ctx)
+  now = ctx.time_ms or 0
+  last_activity = now
+  send_state(true)
+  outbox_drain()
+  render()
+end
+
+function on_tick(ctx, dt_ms)
+  now = ctx.time_ms
+
+  -- timers (guard against timers added during iteration: snapshot length)
+  local n = #timers
+  for i = 1, n do
+    local t = timers[i]
+    if not t.dead and now >= t.at then
+      if t.every then
+        t.at = now + t.every
+        local dt = now - t.last
+        t.last = now
+        t.fn(dt)
+      else
+        t.dead = true
+        t.fn()
+      end
+    end
+  end
+  for i = #timers, 1, -1 do
+    if timers[i].dead then table.remove(timers, i) end
+  end
+
+  -- shake recognizer
+  if #shakes > 0 then
+    local ax, ay, az = imu.accel()
+    local mag = math.sqrt(ax * ax + ay * ay + az * az)
+    for _, sh in ipairs(shakes) do
+      if mag > sh.g and now >= sh.until_ms then
+        sh.until_ms = now + 1000
+        dispatch(sh.name, { mag = math.floor(mag * 100) / 100 }, true)
+      end
+    end
+  end
+
+  -- idle recognizer (an idle intent is not user activity: no resets)
+  for _, w in ipairs(idles) do
+    if not w.fired and now - last_activity >= w.ms then
+      w.fired = true
+      dispatch(w.name, { quiet_ms = now - last_activity }, false)
+    end
+  end
+
+  -- ask timeouts
+  for id, p in pairs(pending) do
+    if now >= p.deadline then
+      pending[id] = nil
+      log.warn("arc ask '" .. p.name .. "' timed out; using fallback")
+      resume(p.co, p.fallback or {})
+    end
+  end
+
+  if store_dirty then send_state(false) end
+  outbox_drain()
+
+  render()
+end
+
+function on_event(ctx, e)
+  -- note: e.ts_ms is millis-since-boot, a different epoch from ctx.time_ms;
+  -- `now` stays at the last tick's value (≤100ms stale, fine for a reflex)
+  if e.name == "arc:reply" then
+    local d = e.data or {}
+    local p = d.id and pending[d.id]
+    if p then
+      pending[d.id] = nil
+      resume(p.co, d)
+    else
+      log.warn("arc: reply for unknown ask id " .. tostring(d.id))
+    end
+  elseif e.name == "arc:hydrate" then
+    if store_raw then
+      for k, v in pairs(e.data or {}) do
+        store_raw[k] = v
+      end
+      dirty = true; store_dirty = true
+    end
+  elseif e.name == "arc:probe" then
+    send_state(true)
+  elseif e.name == "button" then
+    local name = taps[e.index]
+    if name then arc.intent(name, { index = e.index }) end
+  else
+    arc.intent(e.name, e.data)
+  end
+  if dirty then render() end   -- input→pixel inside the 150ms budget
+  outbox_drain()               -- asks shouldn't wait for the next tick
+end
+
+-- end of arc runtime --------------------------------------------------------

--- a/examples/m5stick-arc/app/test.lua
+++ b/examples/m5stick-arc/app/test.lua
@@ -1,0 +1,70 @@
+-- Host-side test of the live-demo generation, using the spike's sim harness.
+-- Run from this directory:  lua test.lua
+
+local sim = dofile("../../../spikes/arc/sim/sim.lua")
+local failed = 0
+local function check(c, what)
+  if not c then failed = failed + 1; print("  FAIL: " .. what) end
+end
+local function has(s, n) return tostring(s):find(n, 1, true) ~= nil end
+
+sim.load("adventure.lua")
+check(has(sim.texts(), "moonlit orchard"), "opening scene")
+check(has(sim.texts(), "A) Take the lantern"), "choices marked")
+check(sim.offscreen() == nil, "default view in bounds: " .. tostring(sim.offscreen()))
+
+-- buttons are swapped for the physical hold: top-edge (1) = A, front (0) = B
+sim.button(1)
+local ask = sim.last_sent("arc:ask")
+check(ask and ask.choice == "a" and ask.tilt ~= nil, "top-edge button asks choice A, with tilt")
+check(has(sim.texts(), "the story stirs"), "authored waiting state")
+check(has(sim.texts(), "A) Take the lantern"), "chosen option echoed during the wait")
+
+-- worst-case reply length (the text-size overflow regression)
+local long = string.rep("the lantern light spills over mossy stones ", 4):sub(1, 140)
+sim.appevent("arc:reply", { id = ask.id, text = long, a = "Sixteen chars ok", b = "Also sixteen ok", scene = 2 })
+sim.tick(1)
+check(has(sim.texts(), "lantern light"), "long reply lands")
+check(sim.offscreen() == nil, "140-char text in bounds: " .. tostring(sim.offscreen()))
+
+-- tilt is reflex-only: no network traffic
+local sent_before = #sim.sent
+sim.accel = { 0.8, 0, 1 }
+sim.tick(3)
+check(#sim.sent == sent_before, "tilt causes no network traffic")
+
+sim.button(0)
+local ask2 = sim.last_sent("arc:ask")
+check(ask2 and ask2.choice == "b", "front button asks choice B")
+sim.appevent("arc:reply", { id = ask2.id, text = "Beat.", a = "Go", b = "Stay", scene = 3 })
+
+-- voice: ptt on/off from the firmware, heard from the server
+sim.appevent("ptt", { state = "on" })
+check(has(sim.texts(), "listening"), "listening state shows while held")
+sim.appevent("ptt", { state = "off" })
+check(has(sim.texts(), "..."), "waiting state after release")
+sim.appevent("heard", { text = "I should step closer" })
+check(has(sim.texts(), '"I should step closer"'), "transcript echoed on screen")
+check(sim.offscreen() == nil, "voice line in bounds")
+sim.tick(70)   -- 7s: transcript line clears itself
+check(not has(sim.texts(), "step closer"), "transcript clears after a few seconds")
+
+-- a voice-routed intent arrives like any other event
+sim.appevent("choose_a", { via = "voice" })
+check(arc.pending("turn"), "voice-injected intent runs the normal handler")
+sim.appevent("arc:reply", { id = (sim.last_sent("arc:ask") or {}).id, text = "Onward.", a = "L", b = "R", scene = 4 })
+
+-- a free-form voice turn arrives as hydration
+sim.appevent("arc:hydrate", { text = "The orchard listens.", a = "Wait", b = "Sing", scene = 5 })
+check(has(sim.texts(), "The orchard listens."), "voice turn hydrates the scene")
+check(arc._raw_store.scene == 5, "hydrated scene number")
+
+-- a broken (model-written) view must not take the app down
+load([[arc.view(function() return ui.col{ pad = "oops", ui.label{ text = S.text } } end)]])()
+sim.tick(2)
+check(#sim.logs > 0 and sim.logs[#sim.logs][1] == "error", "broken view logs an error")
+sim.button(0)
+check(arc.pending("turn"), "app still handles intents after a broken view")
+
+print(failed == 0 and "ALL OK" or (failed .. " FAILURES"))
+os.exit(failed == 0 and 0 or 1)

--- a/examples/m5stick-arc/device/lib/drivers/library.json
+++ b/examples/m5stick-arc/device/lib/drivers/library.json
@@ -1,0 +1,4 @@
+{
+  "name": "M5StickDrivers",
+  "version": "1.0.0"
+}

--- a/examples/m5stick-arc/device/lib/drivers/src/BuzzerDriver.cpp
+++ b/examples/m5stick-arc/device/lib/drivers/src/BuzzerDriver.cpp
@@ -1,0 +1,43 @@
+#include "BuzzerDriver.h"
+#include <M5Unified.h>
+
+extern "C" {
+  #include "lua/lua.h"
+  #include "lua/lauxlib.h"
+}
+
+void BuzzerDriver::begin() {
+  M5.Speaker.setVolume(_volume);
+}
+
+void BuzzerDriver::onAppReset() {
+  M5.Speaker.stop();
+}
+
+// buzzer.beep(freq_hz, duration_ms)
+int BuzzerDriver::beep(lua_State* L) {
+  int freq = (int)luaL_checkinteger(L, 1);
+  int duration = (int)luaL_checkinteger(L, 2);
+  if (freq < 20) freq = 20;
+  if (freq > 20000) freq = 20000;
+  if (duration < 0) duration = 0;
+  if (duration > 5000) duration = 5000;
+  M5.Speaker.tone(freq, duration);
+  return 0;
+}
+
+// buzzer.tone(freq_hz) — continuous tone until stop()
+int BuzzerDriver::tone(lua_State* L) {
+  int freq = (int)luaL_checkinteger(L, 1);
+  if (freq < 20) freq = 20;
+  if (freq > 20000) freq = 20000;
+  M5.Speaker.tone(freq);
+  return 0;
+}
+
+// buzzer.stop()
+int BuzzerDriver::stop(lua_State* L) {
+  (void)L;
+  M5.Speaker.stop();
+  return 0;
+}

--- a/examples/m5stick-arc/device/lib/drivers/src/BuzzerDriver.h
+++ b/examples/m5stick-arc/device/lib/drivers/src/BuzzerDriver.h
@@ -1,0 +1,33 @@
+#ifndef BUZZER_DRIVER_H
+#define BUZZER_DRIVER_H
+
+#include <cstdint>
+#include <ResidentDriver.h>
+#include <ResidentLuaModule.h>
+
+// Resident driver for buzzer via M5Unified Speaker API.
+// Lua API: buzzer.beep(freq_hz, duration_ms)
+//          buzzer.tone(freq_hz)  — continuous until stop
+//          buzzer.stop()
+class BuzzerDriver : public Resident::Driver {
+public:
+  explicit BuzzerDriver(uint8_t volume = 128) : _volume(volume) {}
+
+  const char* name() const override { return "buzzer"; }
+  void begin() override;
+  void onAppReset() override;
+  void registerModule(Resident::LuaModule& m) override {
+    m.method<BuzzerDriver, &BuzzerDriver::beep>("beep")
+     .method<BuzzerDriver, &BuzzerDriver::tone>("tone")
+     .method<BuzzerDriver, &BuzzerDriver::stop>("stop");
+  }
+
+  int beep(lua_State* L);
+  int tone(lua_State* L);
+  int stop(lua_State* L);
+
+private:
+  uint8_t _volume;
+};
+
+#endif // BUZZER_DRIVER_H

--- a/examples/m5stick-arc/device/lib/drivers/src/DisplayDriver.cpp
+++ b/examples/m5stick-arc/device/lib/drivers/src/DisplayDriver.cpp
@@ -1,0 +1,243 @@
+#include "DisplayDriver.h"
+
+extern "C" {
+  #include "lua/lua.h"
+  #include "lua/lualib.h"
+  #include "lua/lauxlib.h"
+}
+
+#ifdef HAS_QRCODE
+#include "qrcode.h"
+#endif
+
+void DisplayDriver::begin() {
+  // setColorDepth must come BEFORE createSprite — the sprite buffer is
+  // allocated at whatever depth is set when create is called.
+  _canvas.setColorDepth(16);
+  _canvas.createSprite(M5.Display.width(), M5.Display.height());
+  _spriteReady = true;
+}
+
+void DisplayDriver::displayText(const char* text) {
+  if (_appRunning) return;
+
+  // Render into the off-screen sprite and push it in one shot. Drawing
+  // directly to M5.Display (fillScreen + print) blacks out the panel between
+  // the clear and the redraw, which flickers visibly when the text updates
+  // frequently — e.g. the once-a-second boot countdown.
+  if (!_spriteReady) {              // sprite not allocated yet (pre-begin)
+    M5.Display.fillScreen(TFT_BLACK);
+    return;
+  }
+  _canvas.fillScreen(TFT_BLACK);
+  _canvas.setTextColor(TFT_WHITE);
+  _canvas.setTextSize(2);
+  _canvas.setScrollRect(4, 60, _canvas.width() - 8, _canvas.height() - 60);
+  _canvas.setTextScroll(true);
+  _canvas.setCursor(4, 60);
+  _canvas.print(text);
+  _canvas.setTextScroll(false);    // restore default; drawn pixels unaffected
+  _canvas.pushSprite(0, 0);
+}
+
+void DisplayDriver::repaint() {
+  if (_spriteReady) _canvas.pushSprite(0, 0);
+}
+
+void DisplayDriver::onAppReset() {
+  if (_spriteReady) {
+    _canvas.fillScreen(TFT_BLACK);
+    _canvas.pushSprite(0, 0);
+  } else {
+    M5.Display.fillScreen(TFT_BLACK);
+  }
+}
+
+// screen.clear(r, g, b) — fill sprite with color (0-255 per channel)
+int DisplayDriver::clear(lua_State* L) {
+  int r = luaL_optinteger(L, 1, 0);
+  int g = luaL_optinteger(L, 2, 0);
+  int b = luaL_optinteger(L, 3, 0);
+
+  uint16_t color = _canvas.color565(r, g, b);
+  _canvas.fillScreen(color);
+  return 0;
+}
+
+// screen.text(x, y, str, [size], [r, g, b]) — draw text at position in sprite.
+// Defaults: size=2, colour=white. Any of size/r/g/b can be omitted from the end.
+int DisplayDriver::text(lua_State* L) {
+  int x = (int)luaL_checknumber(L, 1);
+  int y = (int)luaL_checknumber(L, 2);
+  const char* str = luaL_checkstring(L, 3);
+  int size = (int)luaL_optinteger(L, 4, 2);
+  int r = (int)luaL_optinteger(L, 5, 255);
+  int g = (int)luaL_optinteger(L, 6, 255);
+  int b = (int)luaL_optinteger(L, 7, 255);
+
+  _canvas.setCursor(x, y);
+  _canvas.setTextColor(_canvas.color565(r, g, b));
+  _canvas.setTextSize(size);
+  _canvas.print(str);
+  return 0;
+}
+
+// screen.fill_rect(x, y, w, h, r, g, b) — filled rectangle in sprite
+int DisplayDriver::fillRect(lua_State* L) {
+  int x = (int)luaL_checknumber(L, 1);
+  int y = (int)luaL_checknumber(L, 2);
+  int w = (int)luaL_checknumber(L, 3);
+  int h = (int)luaL_checknumber(L, 4);
+  int r = (int)luaL_checknumber(L, 5);
+  int g = (int)luaL_checknumber(L, 6);
+  int b = (int)luaL_checknumber(L, 7);
+
+  uint16_t color = _canvas.color565(r, g, b);
+  _canvas.fillRect(x, y, w, h, color);
+  return 0;
+}
+
+// screen.rect(x, y, w, h, r, g, b) — 1px outline rectangle in sprite
+int DisplayDriver::rect(lua_State* L) {
+  int x = (int)luaL_checknumber(L, 1);
+  int y = (int)luaL_checknumber(L, 2);
+  int w = (int)luaL_checknumber(L, 3);
+  int h = (int)luaL_checknumber(L, 4);
+  int r = (int)luaL_checknumber(L, 5);
+  int g = (int)luaL_checknumber(L, 6);
+  int b = (int)luaL_checknumber(L, 7);
+
+  uint16_t color = _canvas.color565(r, g, b);
+  _canvas.drawRect(x, y, w, h, color);
+  return 0;
+}
+
+// screen.line(x0, y0, x1, y1, r, g, b) — 1px line in sprite
+int DisplayDriver::line(lua_State* L) {
+  int x0 = (int)luaL_checknumber(L, 1);
+  int y0 = (int)luaL_checknumber(L, 2);
+  int x1 = (int)luaL_checknumber(L, 3);
+  int y1 = (int)luaL_checknumber(L, 4);
+  int r = (int)luaL_checknumber(L, 5);
+  int g = (int)luaL_checknumber(L, 6);
+  int b = (int)luaL_checknumber(L, 7);
+
+  uint16_t color = _canvas.color565(r, g, b);
+  _canvas.drawLine(x0, y0, x1, y1, color);
+  return 0;
+}
+
+// screen.triangle(x0, y0, x1, y1, x2, y2, r, g, b) — 1px outline triangle
+int DisplayDriver::triangle(lua_State* L) {
+  int x0 = (int)luaL_checknumber(L, 1);
+  int y0 = (int)luaL_checknumber(L, 2);
+  int x1 = (int)luaL_checknumber(L, 3);
+  int y1 = (int)luaL_checknumber(L, 4);
+  int x2 = (int)luaL_checknumber(L, 5);
+  int y2 = (int)luaL_checknumber(L, 6);
+  int r = (int)luaL_checknumber(L, 7);
+  int g = (int)luaL_checknumber(L, 8);
+  int b = (int)luaL_checknumber(L, 9);
+
+  uint16_t color = _canvas.color565(r, g, b);
+  _canvas.drawTriangle(x0, y0, x1, y1, x2, y2, color);
+  return 0;
+}
+
+// screen.fill_triangle(x0, y0, x1, y1, x2, y2, r, g, b) — filled triangle
+int DisplayDriver::fillTriangle(lua_State* L) {
+  int x0 = (int)luaL_checknumber(L, 1);
+  int y0 = (int)luaL_checknumber(L, 2);
+  int x1 = (int)luaL_checknumber(L, 3);
+  int y1 = (int)luaL_checknumber(L, 4);
+  int x2 = (int)luaL_checknumber(L, 5);
+  int y2 = (int)luaL_checknumber(L, 6);
+  int r = (int)luaL_checknumber(L, 7);
+  int g = (int)luaL_checknumber(L, 8);
+  int b = (int)luaL_checknumber(L, 9);
+
+  uint16_t color = _canvas.color565(r, g, b);
+  _canvas.fillTriangle(x0, y0, x1, y1, x2, y2, color);
+  return 0;
+}
+
+// screen.pixel(x, y, r, g, b) — set single pixel in sprite
+int DisplayDriver::pixel(lua_State* L) {
+  int x = (int)luaL_checknumber(L, 1);
+  int y = (int)luaL_checknumber(L, 2);
+  int r = (int)luaL_checknumber(L, 3);
+  int g = (int)luaL_checknumber(L, 4);
+  int b = (int)luaL_checknumber(L, 5);
+
+  uint16_t color = _canvas.color565(r, g, b);
+  _canvas.drawPixel(x, y, color);
+  return 0;
+}
+
+// screen.flip() — push sprite framebuffer to display (single SPI transfer).
+int DisplayDriver::flip(lua_State* L) {
+  _canvas.pushSprite(0, 0);
+  return 0;
+}
+
+// screen.set_brightness(0-255)
+int DisplayDriver::setBrightness(lua_State* L) {
+  int brightness = (int)luaL_checknumber(L, 1);
+  if (brightness < 0) brightness = 0;
+  if (brightness > 255) brightness = 255;
+  M5.Display.setBrightness(brightness);
+  return 0;
+}
+
+// screen.width() — returns display width in pixels
+int DisplayDriver::width(lua_State* L) {
+  lua_pushinteger(L, M5.Display.width());
+  return 1;
+}
+
+// screen.height() — returns display height in pixels
+int DisplayDriver::height(lua_State* L) {
+  lua_pushinteger(L, M5.Display.height());
+  return 1;
+}
+
+#ifdef HAS_QRCODE
+// screen.qr(x, y, str, [scale], [r, g, b]) — draw QR code in sprite.
+// Auto-picks the smallest QR version (3..10, ECC low) that fits the text.
+// Defaults: scale=4, colour=black. Background is not drawn — caller is
+// responsible for clearing to a light colour behind the QR for scannability.
+int DisplayDriver::qr(lua_State* L) {
+  int x = (int)luaL_checknumber(L, 1);
+  int y = (int)luaL_checknumber(L, 2);
+  const char* str = luaL_checkstring(L, 3);
+  int scale = (int)luaL_optinteger(L, 4, 4);
+  int r = (int)luaL_optinteger(L, 5, 0);
+  int g = (int)luaL_optinteger(L, 6, 0);
+  int b = (int)luaL_optinteger(L, 7, 0);
+  if (scale < 1) scale = 1;
+
+  // qrcode_getBufferSize is a runtime fn, not a macro — hardcode a size
+  // generous for version 10 (actual requirement ~407 bytes).
+  static constexpr uint8_t QR_MAX_VERSION = 10;
+  static uint8_t qr_buffer[512];
+  QRCode qrcode;
+  int8_t result = -1;
+  for (uint8_t version = 3; version <= QR_MAX_VERSION; version++) {
+    result = qrcode_initText(&qrcode, qr_buffer, version, ECC_LOW, str);
+    if (result == 0) break;
+  }
+  if (result != 0) {
+    return luaL_error(L, "screen.qr: text too long for QR v%d", QR_MAX_VERSION);
+  }
+
+  uint16_t color = _canvas.color565(r, g, b);
+  for (uint8_t py = 0; py < qrcode.size; py++) {
+    for (uint8_t px = 0; px < qrcode.size; px++) {
+      if (qrcode_getModule(&qrcode, px, py)) {
+        _canvas.fillRect(x + px * scale, y + py * scale, scale, scale, color);
+      }
+    }
+  }
+  return 0;
+}
+#endif

--- a/examples/m5stick-arc/device/lib/drivers/src/DisplayDriver.h
+++ b/examples/m5stick-arc/device/lib/drivers/src/DisplayDriver.h
@@ -1,0 +1,73 @@
+#ifndef DISPLAY_DRIVER_H
+#define DISPLAY_DRIVER_H
+
+#include <ResidentDriver.h>
+#include <ResidentLuaModule.h>
+#include <ResidentStatusDisplay.h>
+#include <M5Unified.h>
+
+// A StatusDisplay (which is a Driver): renders Lua screen.* via an off-screen
+// sprite and writes connection-state text directly to the display. Status
+// display calls are suppressed while an app is running.
+class DisplayDriver : public Resident::StatusDisplay {
+public:
+  const char* name() const override { return "screen"; }
+
+  void registerModule(Resident::LuaModule& m) override {
+    m.method<DisplayDriver, &DisplayDriver::clear>("clear")
+     .method<DisplayDriver, &DisplayDriver::text>("text")
+     .method<DisplayDriver, &DisplayDriver::fillRect>("fill_rect")
+     .method<DisplayDriver, &DisplayDriver::rect>("rect")
+     .method<DisplayDriver, &DisplayDriver::line>("line")
+     .method<DisplayDriver, &DisplayDriver::triangle>("triangle")
+     .method<DisplayDriver, &DisplayDriver::fillTriangle>("fill_triangle")
+     .method<DisplayDriver, &DisplayDriver::pixel>("pixel")
+     .method<DisplayDriver, &DisplayDriver::flip>("flip")
+     .method<DisplayDriver, &DisplayDriver::setBrightness>("set_brightness")
+     .method<DisplayDriver, &DisplayDriver::width>("width")
+     .method<DisplayDriver, &DisplayDriver::height>("height");
+#ifdef HAS_QRCODE
+    m.method<DisplayDriver, &DisplayDriver::qr>("qr");
+#endif
+  }
+
+  void onAppReset() override;
+  void onAppRunning(bool running) override { _appRunning = running; }
+
+  // Resident::StatusDisplay — writes directly to M5.Display (not sprite)
+  void displayText(const char* text) override;
+
+  // Call once after M5.begin() to create the sprite framebuffer
+  void begin() override;
+
+  // Re-push the current off-screen sprite to the display without redrawing it.
+  // Restores the last app frame after a direct displayText() overlay (e.g. the
+  // m5stick-voice "Listening" prompt). Essential for apps that render only in
+  // init(); tick-driven apps would otherwise redraw on their next on_tick.
+  void repaint();
+
+protected:
+  M5Canvas _canvas{&M5.Display};
+
+private:
+  bool _spriteReady = false;
+  bool _appRunning = false;
+
+  int clear(lua_State* L);
+  int text(lua_State* L);
+  int fillRect(lua_State* L);
+  int rect(lua_State* L);
+  int line(lua_State* L);
+  int triangle(lua_State* L);
+  int fillTriangle(lua_State* L);
+  int pixel(lua_State* L);
+  int flip(lua_State* L);
+  int setBrightness(lua_State* L);
+  int width(lua_State* L);
+  int height(lua_State* L);
+#ifdef HAS_QRCODE
+  int qr(lua_State* L);
+#endif
+};
+
+#endif // DISPLAY_DRIVER_H

--- a/examples/m5stick-arc/device/lib/drivers/src/IMUDriver.cpp
+++ b/examples/m5stick-arc/device/lib/drivers/src/IMUDriver.cpp
@@ -1,0 +1,68 @@
+#include "IMUDriver.h"
+#include <M5Unified.h>
+
+extern "C" {
+  #include "lua/lua.h"
+  #include "lua/lualib.h"
+  #include "lua/lauxlib.h"
+}
+
+// Body-frame convention used by all imu.* Lua bindings:
+//   body-X = long axis of the device (USB port toward -X)
+//   body-Y = short axis
+//   body-Z = screen normal (positive points out of the screen toward the viewer)
+// At rest face-up on a table, accel should read approximately (0, 0, +1g).
+// Gyro uses the right-hand rule: thumb along the +axis, positive rotation is
+// CCW when looking toward the tip of the thumb.
+//
+// M5Unified reports values in the chip's own frame, which differs per board:
+//   M5StickC Plus2 — MPU6886 mounted rotated; X and Y are swapped.
+//   M5StickS3      — IMU X axis is inverted; Y and Z match the body frame
+//                    (verified on hardware: flat and landscape read correct,
+//                    portrait was inverted before this remap).
+// remapToBodyFrame() corrects this so Lua apps get consistent body-frame
+// readings. Selection is compile-time via the per-env board macros (see
+// platformio.ini / main.cpp); the S3 env's PlatformIO board is a generic
+// esp32-s3-devkitc-1, so a runtime M5.getBoard() check can't identify it.
+// Verify and extend this remap when adding a new board.
+static inline void remapToBodyFrame(float& x, float& y) {
+#if defined(BOARD_M5STICKS3)
+  x = -x;
+#else  // BOARD_M5STICK_C_PLUS2
+  if (M5.getBoard() == m5::board_t::board_M5StickCPlus2) {
+    float tmp = x;
+    x = y;
+    y = tmp;
+  }
+#endif
+}
+
+// imu.accel() -> ax, ay, az (g-force, body frame)
+int IMUDriver::accel(lua_State* L) {
+  M5.Imu.update();
+  auto data = M5.Imu.getImuData();
+  float ax = data.accel.x, ay = data.accel.y, az = data.accel.z;
+  remapToBodyFrame(ax, ay);
+  lua_pushnumber(L, ax);
+  lua_pushnumber(L, ay);
+  lua_pushnumber(L, az);
+  return 3;
+}
+
+// imu.gyro() -> gx, gy, gz (degrees/sec, body frame)
+int IMUDriver::gyro(lua_State* L) {
+  M5.Imu.update();
+  auto data = M5.Imu.getImuData();
+  float gx = data.gyro.x, gy = data.gyro.y, gz = data.gyro.z;
+  remapToBodyFrame(gx, gy);
+  lua_pushnumber(L, gx);
+  lua_pushnumber(L, gy);
+  lua_pushnumber(L, gz);
+  return 3;
+}
+
+// imu.temp() -> not supported by M5Unified IMU_Class, returns 0
+int IMUDriver::temp(lua_State* L) {
+  lua_pushnumber(L, 0);
+  return 1;
+}

--- a/examples/m5stick-arc/device/lib/drivers/src/IMUDriver.h
+++ b/examples/m5stick-arc/device/lib/drivers/src/IMUDriver.h
@@ -1,0 +1,25 @@
+#ifndef IMU_DRIVER_H
+#define IMU_DRIVER_H
+
+#include <ResidentDriver.h>
+#include <ResidentLuaModule.h>
+
+// Resident driver wrapping M5Unified's IMU (MPU6886) for Lua access.
+// Lua API: imu.accel() -> ax,ay,az (g-force, body frame)
+//          imu.gyro()  -> gx,gy,gz (degrees/sec, body frame)
+//          imu.temp()  -> not supported, returns 0
+class IMUDriver : public Resident::Driver {
+public:
+  const char* name() const override { return "imu"; }
+  void registerModule(Resident::LuaModule& m) override {
+    m.method<IMUDriver, &IMUDriver::accel>("accel")
+     .method<IMUDriver, &IMUDriver::gyro>("gyro")
+     .method<IMUDriver, &IMUDriver::temp>("temp");
+  }
+
+  int accel(lua_State* L);
+  int gyro(lua_State* L);
+  int temp(lua_State* L);
+};
+
+#endif // IMU_DRIVER_H

--- a/examples/m5stick-arc/device/lib/drivers/src/PushButtonsDriver.cpp
+++ b/examples/m5stick-arc/device/lib/drivers/src/PushButtonsDriver.cpp
@@ -1,0 +1,128 @@
+#include "PushButtonsDriver.h"
+#include <Arduino.h>
+
+extern "C" {
+  #include "lua/lua.h"
+  #include "lua/lualib.h"
+  #include "lua/lauxlib.h"
+}
+
+PushButtonsDriver::PushButtonsDriver(const PushButtonsConfig& config)
+  : _config(config)
+{
+  for (uint8_t i = 0; i < MAX_BUTTONS; i++) {
+    _buttons[i] = {true, 0, 0, false, 0, false};
+  }
+}
+
+void PushButtonsDriver::begin()
+{
+  uint8_t n = _config.numButtons;
+  if (n > MAX_BUTTONS) n = MAX_BUTTONS;
+
+  for (uint8_t i = 0; i < n; i++) {
+    pinMode(_config.pins[i], INPUT_PULLUP);
+    bool state = digitalRead(_config.pins[i]);
+    _buttons[i] = {state, 0, _buttons[i].pressCount, false, 0, false};
+    Serial.printf("PushButton[%d] on GPIO %d\n", i, _config.pins[i]);
+  }
+}
+
+void PushButtonsDriver::update()
+{
+  uint8_t n = _config.numButtons;
+  if (n > MAX_BUTTONS) n = MAX_BUTTONS;
+
+  unsigned long now = millis();
+
+  for (uint8_t i = 0; i < n; i++) {
+    bool current = digitalRead(_config.pins[i]);
+    auto& btn = _buttons[i];
+
+    // Debounced press detection (HIGH → LOW)
+    if (current == LOW && btn.lastState == HIGH) {
+      if (now - btn.lastDebounceTime > DEBOUNCE_MS) {
+        btn.lastDebounceTime = now;
+        btn.isDown = true;
+        btn.downStartTime = now;
+        btn.longPressTriggered = false;
+      }
+    }
+
+    // Check long-press threshold while held
+    if (btn.isDown && !btn.longPressTriggered && _longPress[i].callback) {
+      if (now - btn.downStartTime >= _longPress[i].thresholdMs) {
+        btn.longPressTriggered = true;
+        _longPress[i].callback(true);
+      }
+    }
+
+    // Release detection (LOW → HIGH), debounced so contact chatter mid-hold
+    // can't momentarily read "released".
+    if (current == HIGH && btn.lastState == LOW) {
+      if (now - btn.lastDebounceTime > DEBOUNCE_MS) {
+        btn.lastDebounceTime = now;
+        if (btn.isDown) {
+          if (btn.longPressTriggered) {
+            if (_longPress[i].callback) {
+              _longPress[i].callback(false);
+            }
+          } else {
+            btn.pressCount++;
+            Resident::EventField fields[] = {
+              {"index", Resident::EventField::INT, {.i = (int)i}},
+              {"count", Resident::EventField::INT, {.i = (int)btn.pressCount}}
+            };
+            sendEvent("button", fields, 2);
+            Serial.printf("PushButton[%d] pressed (count=%d)\n", i, btn.pressCount);
+          }
+          btn.isDown = false;
+        }
+      }
+    }
+
+    btn.lastState = current;
+  }
+}
+
+bool PushButtonsDriver::pressed()
+{
+  // Debounced held-level of button 0, maintained by update() (which the
+  // runtime now calls every loop while this is the system button — including
+  // during the boot countdown).
+  return _buttons[0].isDown;
+}
+
+void PushButtonsDriver::setLongPress(uint8_t buttonIndex, LongPressFn callback,
+                                      unsigned long thresholdMs)
+{
+  if (buttonIndex < MAX_BUTTONS) {
+    _longPress[buttonIndex].callback = callback;
+    _longPress[buttonIndex].thresholdMs = thresholdMs;
+  }
+}
+
+void PushButtonsDriver::onAppReset()
+{
+  for (uint8_t i = 0; i < MAX_BUTTONS; i++) {
+    _buttons[i].pressCount = 0;
+    // Don't clear _longPress — those are device config, not app state
+  }
+}
+
+uint16_t PushButtonsDriver::getTotalPressCount() const
+{
+  uint16_t total = 0;
+  uint8_t n = _config.numButtons;
+  if (n > MAX_BUTTONS) n = MAX_BUTTONS;
+  for (uint8_t i = 0; i < n; i++) {
+    total += _buttons[i].pressCount;
+  }
+  return total;
+}
+
+int PushButtonsDriver::pressCount(lua_State* L)
+{
+  lua_pushinteger(L, getTotalPressCount());
+  return 1;
+}

--- a/examples/m5stick-arc/device/lib/drivers/src/PushButtonsDriver.h
+++ b/examples/m5stick-arc/device/lib/drivers/src/PushButtonsDriver.h
@@ -1,0 +1,66 @@
+#ifndef PUSH_BUTTONS_DRIVER_H
+#define PUSH_BUTTONS_DRIVER_H
+
+#include <cstdint>
+#include <ResidentDriver.h>
+#include <ResidentLuaModule.h>
+#include <ResidentSystemButton.h>
+
+struct PushButtonsConfig {
+  uint8_t numButtons;
+  const uint8_t* pins;
+};
+
+// Also acts as the Resident::SystemButton (button 0 — the front button), so the
+// runtime can read it directly during the boot countdown (tap = load now, long
+// press = forget the saved app), independent of the app-facing button events.
+class PushButtonsDriver : public Resident::SystemButton {
+public:
+  explicit PushButtonsDriver(const PushButtonsConfig& config);
+
+  const char* name() const override { return "button"; }
+  void begin() override;
+  void update() override;
+  void onAppReset() override;
+  void registerModule(Resident::LuaModule& m) override {
+    m.method<PushButtonsDriver, &PushButtonsDriver::pressCount>("press_count");
+  }
+
+  int pressCount(lua_State* L);
+
+  // Resident::SystemButton — debounced held-level of button 0, maintained by
+  // update() (called every loop while this is the system button).
+  bool pressed() override;
+
+  uint16_t getTotalPressCount() const;
+
+  using LongPressFn = void(*)(bool started);
+  void setLongPress(uint8_t buttonIndex, LongPressFn callback,
+                    unsigned long thresholdMs = 200);
+
+private:
+  static constexpr uint8_t MAX_BUTTONS = 4;
+  static constexpr unsigned long DEBOUNCE_MS = 50;
+
+  const PushButtonsConfig& _config;
+
+  struct ButtonState {
+    bool lastState;
+    unsigned long lastDebounceTime;
+    uint8_t pressCount;
+    bool isDown;
+    unsigned long downStartTime;
+    bool longPressTriggered;
+  };
+
+  ButtonState _buttons[MAX_BUTTONS];
+
+  struct LongPressConfig {
+    LongPressFn callback = nullptr;
+    unsigned long thresholdMs = 500;
+  };
+  LongPressConfig _longPress[MAX_BUTTONS];
+
+};
+
+#endif // PUSH_BUTTONS_DRIVER_H

--- a/examples/m5stick-arc/device/partitions.csv
+++ b/examples/m5stick-arc/device/partitions.csv
@@ -1,0 +1,6 @@
+# Partition Table — 8MB flash, single app
+# Name,             Type,               SubType,    Offset,     Size,       Flags
+nvs,                data,               nvs,        0x9000,     0x5000,
+otadata,            data,               ota,        0xe000,     0x2000,
+app0,               app,                ota_0,      0x10000,    0x600000,
+spiffs,             data,               spiffs,     0x610000,   0x1F0000,

--- a/examples/m5stick-arc/device/platformio.ini
+++ b/examples/m5stick-arc/device/platformio.ini
@@ -1,0 +1,50 @@
+[platformio]
+default_envs = m5stick
+
+[env]
+platform = espressif32@6.12.0
+framework = arduino
+lib_deps =
+    ; resident: symlink to in-tree source. CI has no SSH key for this private repo.
+    symlink://../../..
+    ; PIO quirk: symlinking a parent that contains this project suppresses PIO's
+    ; auto-scan of our own lib/, so lib/drivers/M5StickDrivers vanishes. Re-add it.
+    symlink://lib/drivers
+    git+https://github.com/inanimate-tech/courier.git
+    tzapu/WiFiManager@^2.0.17
+    bblanchon/ArduinoJson@^7.4.2
+    ropg/ezTime@^0.8.3
+    fischer-simon/Esp32Lua@^5.4.7
+    m5stack/M5Unified
+monitor_speed = 115200
+; Resident headers use std::optional (C++17). arduino-espressif32 6.12
+; defaults to gnu++11, so override at the env level.
+build_unflags = -std=gnu++11
+build_flags =
+    -std=gnu++17
+    -DBOARD_HAS_PSRAM
+
+[env:m5stick]
+board = m5stick-c
+board_build.flash_size = 8MB
+board_upload.flash_size = 8MB
+board_upload.maximum_size = 8388608
+board_build.partitions = partitions.csv
+board_build.flash_mode = qio
+board_build.f_flash = 80000000L
+build_flags =
+    ${env.build_flags}
+    -DBOARD_M5STICK_C_PLUS2
+
+[env:m5sticks3]
+board = esp32-s3-devkitc-1
+board_build.flash_size = 8MB
+board_build.arduino.memory_type = qio_opi
+lib_deps =
+    ${env.lib_deps}
+    M5PM1=https://github.com/m5stack/M5PM1
+build_flags =
+    ${env.build_flags}
+    -DARDUINO_USB_MODE=1
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DBOARD_M5STICKS3

--- a/examples/m5stick-arc/device/src/le_roots.h
+++ b/examples/m5stick-arc/device/src/le_roots.h
@@ -1,0 +1,55 @@
+// Let's Encrypt roots (ISRG Root X1 + X2) — the CA chain behind
+// *.workers.dev. Courier's embedded fallback root is GTS Root R4
+// (Cloudflare universal SSL); workers.dev serves Let's Encrypt instead,
+// so builds without the IDF cert bundle must pin these. Public certs
+// from https://letsencrypt.org/certificates/.
+#pragma once
+
+static const char* LE_ROOTS_PEM =
+    // ISRG Root X1
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw\n"
+    "TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh\n"
+    "cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4\n"
+    "WhcNMzUwNjA0MTEwNDM4WjBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJu\n"
+    "ZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBY\n"
+    "MTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK3oJHP0FDfzm54rVygc\n"
+    "h77ct984kIxuPOZXoHj3dcKi/vVqbvYATyjb3miGbESTtrFj/RQSa78f0uoxmyF+\n"
+    "0TM8ukj13Xnfs7j/EvEhmkvBioZxaUpmZmyPfjxwv60pIgbz5MDmgK7iS4+3mX6U\n"
+    "A5/TR5d8mUgjU+g4rk8Kb4Mu0UlXjIB0ttov0DiNewNwIRt18jA8+o+u3dpjq+sW\n"
+    "T8KOEUt+zwvo/7V3LvSye0rgTBIlDHCNAymg4VMk7BPZ7hm/ELNKjD+Jo2FR3qyH\n"
+    "B5T0Y3HsLuJvW5iB4YlcNHlsdu87kGJ55tukmi8mxdAQ4Q7e2RCOFvu396j3x+UC\n"
+    "B5iPNgiV5+I3lg02dZ77DnKxHZu8A/lJBdiB3QW0KtZB6awBdpUKD9jf1b0SHzUv\n"
+    "KBds0pjBqAlkd25HN7rOrFleaJ1/ctaJxQZBKT5ZPt0m9STJEadao0xAH0ahmbWn\n"
+    "OlFuhjuefXKnEgV4We0+UXgVCwOPjdAvBbI+e0ocS3MFEvzG6uBQE3xDk3SzynTn\n"
+    "jh8BCNAw1FtxNrQHusEwMFxIt4I7mKZ9YIqioymCzLq9gwQbooMDQaHWBfEbwrbw\n"
+    "qHyGO0aoSCqI3Haadr8faqU9GY/rOPNk3sgrDQoo//fb4hVC1CLQJ13hef4Y53CI\n"
+    "rU7m2Ys6xt0nUW7/vGT1M0NPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNV\n"
+    "HRMBAf8EBTADAQH/MB0GA1UdDgQWBBR5tFnme7bl5AFzgAiIyBpY9umbbjANBgkq\n"
+    "hkiG9w0BAQsFAAOCAgEAVR9YqbyyqFDQDLHYGmkgJykIrGF1XIpu+ILlaS/V9lZL\n"
+    "ubhzEFnTIZd+50xx+7LSYK05qAvqFyFWhfFQDlnrzuBZ6brJFe+GnY+EgPbk6ZGQ\n"
+    "3BebYhtF8GaV0nxvwuo77x/Py9auJ/GpsMiu/X1+mvoiBOv/2X/qkSsisRcOj/KK\n"
+    "NFtY2PwByVS5uCbMiogziUwthDyC3+6WVwW6LLv3xLfHTjuCvjHIInNzktHCgKQ5\n"
+    "ORAzI4JMPJ+GslWYHb4phowim57iaztXOoJwTdwJx4nLCgdNbOhdjsnvzqvHu7Ur\n"
+    "TkXWStAmzOVyyghqpZXjFaH3pO3JLF+l+/+sKAIuvtd7u+Nxe5AW0wdeRlN8NwdC\n"
+    "jNPElpzVmbUq4JUagEiuTDkHzsxHpFKVK7q4+63SM1N95R1NbdWhscdCb+ZAJzVc\n"
+    "oyi3B43njTOQ5yOf+1CceWxG1bQVs5ZufpsMljq4Ui0/1lvh+wjChP4kqKOJ2qxq\n"
+    "4RgqsahDYVvTH9w7jXbyLeiNdd8XM2w9U/t7y0Ff/9yi0GE44Za4rF2LN9d11TPA\n"
+    "mRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d\n"
+    "emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=\n"
+    "-----END CERTIFICATE-----\n"
+    // ISRG Root X2
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIICGzCCAaGgAwIBAgIQQdKd0XLq7qeAwSxs6S+HUjAKBggqhkjOPQQDAzBPMQsw\n"
+    "CQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJuZXQgU2VjdXJpdHkgUmVzZWFyY2gg\n"
+    "R3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBYMjAeFw0yMDA5MDQwMDAwMDBaFw00\n"
+    "MDA5MTcxNjAwMDBaME8xCzAJBgNVBAYTAlVTMSkwJwYDVQQKEyBJbnRlcm5ldCBT\n"
+    "ZWN1cml0eSBSZXNlYXJjaCBHcm91cDEVMBMGA1UEAxMMSVNSRyBSb290IFgyMHYw\n"
+    "EAYHKoZIzj0CAQYFK4EEACIDYgAEzZvVn4CDCuwJSvMWSj5cz3es3mcFDR0HttwW\n"
+    "+1qLFNvicWDEukWVEYmO6gbf9yoWHKS5xcUy4APgHoIYOIvXRdgKam7mAHf7AlF9\n"
+    "ItgKbppbd9/w+kHsOdx1ymgHDB/qo0IwQDAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0T\n"
+    "AQH/BAUwAwEB/zAdBgNVHQ4EFgQUfEKWrt5LSDv6kviejM9ti6lyN5UwCgYIKoZI\n"
+    "zj0EAwMDaAAwZQIwe3lORlCEwkSHRhtFcP9Ymd70/aTSVaYgLXTWNLxBo1BfASdW\n"
+    "tL4ndQavEi51mI38AjEAi/V3bNTIZargCyzuFJ0nN6T5U6VR5CmD1/iQMVtCnwr1\n"
+    "/q4AaOeMSQ+2b1tbFfLn\n"
+    "-----END CERTIFICATE-----\n";

--- a/examples/m5stick-arc/device/src/main.cpp
+++ b/examples/m5stick-arc/device/src/main.cpp
@@ -1,0 +1,91 @@
+#include <M5Unified.h>
+#include <Resident.h>
+#include "le_roots.h"
+#include "DisplayDriver.h"
+#include "IMUDriver.h"
+#include "BuzzerDriver.h"
+#include "PushButtonsDriver.h"
+
+// The m5stick-arc server (examples/m5stick-arc/server) — an ArcAgent relay
+// that answers the app's arc:ask events with inference. Deploy it with
+// wrangler and put the printed hostname here (or pass it at build time:
+// PLATFORMIO_BUILD_FLAGS='-DARC_HOST=\"<host>\"' pio run ...). Protocol:
+//   wss://<host>/devices/<deviceId>              ← device WS (here)
+//   POST https://<host>/devices/<deviceId>/send  ← push JSON to the device
+//   POST https://<host>/devices/<deviceId>/arc/push ← push the arc adventure app
+#ifndef ARC_HOST
+#define ARC_HOST "m5stick-arc.YOUR-CF-ACCOUNT.workers.dev"
+#endif
+static constexpr const char* RESIDENT_HOST = ARC_HOST;
+static constexpr uint16_t RESIDENT_PORT = 443;
+
+// Board-specific button pins. M5StickC Plus2 (ESP32 classic): GPIO 37 + 39.
+// M5StickS3 (ESP32-S3 with OPI PSRAM): GPIO 11 + 12. On the S3, GPIO 37 is
+// part of the OPI PSRAM interface — reading it via digitalRead() triggers a
+// watchdog reset.
+#if defined(BOARD_M5STICKS3)
+static constexpr uint8_t BUTTON_PINS[] = {11, 12};
+#else  // BOARD_M5STICK_C_PLUS2 (default)
+static constexpr uint8_t BUTTON_PINS[] = {37, 39};
+#endif
+static constexpr PushButtonsConfig buttonConfig = {.numButtons = 2, .pins = BUTTON_PINS};
+
+DisplayDriver displayDriver;
+IMUDriver imuDriver;
+BuzzerDriver buzzerDriver{255};
+PushButtonsDriver buttonDriver{buttonConfig};
+
+Resident::SandboxConfig makeConfig() {
+    Resident::SandboxConfig cfg;
+    cfg.deviceType    = "arc-stick";
+    cfg.extensions    = {&displayDriver, &imuDriver, &buzzerDriver, &buttonDriver};
+    cfg.systemDisplay = &displayDriver;
+    cfg.systemButton  = &buttonDriver;   // front button: tap = load, hold = forget
+
+    // Courier::Config has a constructor with default args, so designated
+    // initializers (.host = ...) don't compile under strict ESP-IDF builds.
+    // Use direct field assignment.
+    Courier::Config courier;
+    courier.host = RESIDENT_HOST;
+    courier.port = RESIDENT_PORT;
+    cfg.network  = courier;
+
+    return cfg;
+}
+
+Resident::Sandbox sandbox{makeConfig()};
+
+void setup() {
+    Serial.begin(115200);
+    delay(2000);  // Wait for USB CDC on M5StickS3; harmless on M5Stick
+    auto cfg = M5.config();
+    M5.begin(cfg);
+    M5.Display.setRotation(1);
+
+    // workers.dev serves a Let's Encrypt chain; this Arduino build has no IDF
+    // cert bundle, and Courier's embedded fallback root (GTS Root R4) only
+    // covers Cloudflare universal SSL. Pin the ISRG roots for the WS TLS.
+    sandbox.onConfigureNetwork([](Courier::Client& c) {
+        c.transport<Courier::WebSocketTransport>("ws").onConfigure(
+            [](esp_websocket_client_config_t& cfg) { cfg.cert_pem = LE_ROOTS_PEM; });
+    });
+
+    // Override the default /agents/<type>-agent/<deviceId> path with the
+    // canonical /devices/<deviceId> path used by the DeviceAgent relay.
+    sandbox.onTransportsWillConnect([]() {
+        String wsPath = String("/devices/") + sandbox.getDeviceId();
+        sandbox.ws().setEndpoint(RESIDENT_HOST, RESIDENT_PORT, wsPath.c_str());
+    });
+
+    // No bootstrap app on connect: Resident now shows the device ID itself
+    // (the boot countdown screen) and auto-restores the last persisted app.
+    // A hand-rolled onConnected loadApp here would cancel that restore and
+    // overwrite the persisted app in NVS.
+
+    sandbox.setup();
+}
+
+void loop() {
+    M5.update();
+    sandbox.loop();
+}

--- a/examples/m5stick-arc/device/src/main.cpp
+++ b/examples/m5stick-arc/device/src/main.cpp
@@ -1,5 +1,7 @@
 #include <M5Unified.h>
 #include <Resident.h>
+#include <ResidentM5Mic.h>   // opt-in M5 mic driver (not pulled in by Resident.h)
+#include <ArduinoJson.h>
 #include "le_roots.h"
 #include "DisplayDriver.h"
 #include "IMUDriver.h"
@@ -34,6 +36,7 @@ DisplayDriver displayDriver;
 IMUDriver imuDriver;
 BuzzerDriver buzzerDriver{255};
 PushButtonsDriver buttonDriver{buttonConfig};
+Resident::M5Mic micDriver;   // 16 kHz mono PCM; capture runs only while streaming
 
 Resident::SandboxConfig makeConfig() {
     Resident::SandboxConfig cfg;
@@ -41,6 +44,7 @@ Resident::SandboxConfig makeConfig() {
     cfg.extensions    = {&displayDriver, &imuDriver, &buzzerDriver, &buttonDriver};
     cfg.systemDisplay = &displayDriver;
     cfg.systemButton  = &buttonDriver;   // front button: tap = load, hold = forget
+    cfg.systemMic     = &micDriver;      // push-to-talk source (see setLongPress below)
 
     // Courier::Config has a constructor with default args, so designated
     // initializers (.host = ...) don't compile under strict ESP-IDF builds.
@@ -76,6 +80,28 @@ void setup() {
         String wsPath = String("/devices/") + sandbox.getDeviceId();
         sandbox.ws().setEndpoint(RESIDENT_HOST, RESIDENT_PORT, wsPath.c_str());
     });
+
+    // Push-to-talk on the front button (index 0 — also choice B on tap). The
+    // driver's long-press detector both fires the hold callback AND
+    // suppresses the tap event on release, so holding to talk never
+    // registers as a choice. While held: a system-channel "voice" envelope
+    // brackets the raw 16 kHz PCM the mic pump streams over the binary WS,
+    // and the running arc app hears "ptt" events so its view can show a
+    // listening state. Transcription and interpretation happen server-side.
+    buttonDriver.setLongPress(0, [](bool held) {
+        JsonDocument doc;
+        doc["type"]  = "voice";
+        doc["state"] = held ? "start" : "end";
+        if (held) {
+            sandbox.sendSystem(doc);         // envelope precedes binary frames
+            sandbox.startMicStream();
+            sandbox.sendAppEvent("ptt", "{\"state\":\"on\"}");
+        } else {
+            sandbox.stopMicStream();
+            sandbox.sendSystem(doc);
+            sandbox.sendAppEvent("ptt", "{\"state\":\"off\"}");
+        }
+    }, 500);
 
     // No bootstrap app on connect: Resident now shows the device ID itself
     // (the boot countdown screen) and auto-restores the last persisted app.

--- a/examples/m5stick-arc/server/env.d.ts
+++ b/examples/m5stick-arc/server/env.d.ts
@@ -1,0 +1,23 @@
+/* eslint-disable */
+declare namespace Cloudflare {
+  interface GlobalProps {
+    mainModule: typeof import("./src/worker");
+    durableNamespaces: "ArcAgent";
+  }
+  interface Env {
+    ArcAgent: DurableObjectNamespace<import("./src/worker").ArcAgent>;
+    AI: Ai;
+    CLOUDFLARE_AIG_ID: string;
+  }
+}
+interface Env extends Cloudflare.Env {}
+
+declare module "*.lua" {
+  const src: string;
+  export default src;
+}
+
+declare module "luaparse" {
+  const luaparse: { parse(code: string, opts?: { luaVersion?: string }): unknown };
+  export default luaparse;
+}

--- a/examples/m5stick-arc/server/package-lock.json
+++ b/examples/m5stick-arc/server/package-lock.json
@@ -1,0 +1,4447 @@
+{
+  "name": "m5stick-arc-server",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "m5stick-arc-server",
+      "version": "0.0.0",
+      "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.94",
+        "@inanimate/resident": "^0.1.0",
+        "agents": "^0.10.1",
+        "ai": "^6.0.220",
+        "luaparse": "^0.3.1",
+        "workers-ai-provider": "^3.3.1",
+        "zod": "^4.3.6"
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20260411.1",
+        "typescript": "^6.0.2",
+        "wrangler": "4.81.1"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.104",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.104.tgz",
+      "integrity": "sha512-D1d/whdUWF8KrXr9TzK6/S1wD9WmmxJ5DRWgGJX6Ip8iZW0up/yRtWuZwTkuX86bOPQTd2c370lIVteEBUGxPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.14",
+        "@ai-sdk/provider-utils": "4.0.41"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.160",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.160.tgz",
+      "integrity": "sha512-yL024nICtDX74vFkfFJl8t7uHlA3BXl/5C+Ah92dPunI0U2WPCPhTnmiWu4zEYTjZmmvFOC3pDojniLsHkUFqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.14",
+        "@ai-sdk/provider-utils": "4.0.41",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.14.tgz",
+      "integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.41",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.41.tgz",
+      "integrity": "sha512-I7hhjfw01yEI8NkuAsT8Mv6xbWFr/lqLXMdaJQ2zWfXEpxog1eT7skDcv1+RY29/+5btzH8wD+vVvy48bk9oNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.14",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8",
+        "undici": "^5.29.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "11.9.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz",
+      "integrity": "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
+      "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
+      "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/helper-replace-supers": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
+      "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
+      "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
+      "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
+      "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-decorators": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.29.7.tgz",
+      "integrity": "sha512-EtU0Hi3GvrTqD56xKmZvV/uCXK2ZbwVNPNLAquVItcAZpUhkXwWlo3Fmj0c2LxgSf2I8IDULeAepwNP1OefLXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-syntax-decorators": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-decorators": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.29.7.tgz",
+      "integrity": "sha512-9MTTLbF39X6sqM92JPEsoI7++26hjZvzkxKZy64aMhWLH2mPkJ/Q3AV4QLmls3R14FpSpkOwQQfUh962JGQxxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime-corejs3": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.7.tgz",
+      "integrity": "sha512-ppj9ouYku+RX0ljtgZd+KMO5mkM2bCqg8H2PYAFWnLsHEIKIdRojqbJ2i3eVHrisuxy7nOFCmngTDdWtUCdXUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "core-js-pure": "^3.48.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "license": "MIT"
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+      "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.0.tgz",
+      "integrity": "sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260409.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260409.1.tgz",
+      "integrity": "sha512-h/bkaC0HJL63aqAGnV0oagqpBiTSstabODThkeMSbG8kctl0Jb4jlq1pNHJPmYGazFNtfyagrUZFb6HN22GX7w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260409.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260409.1.tgz",
+      "integrity": "sha512-HTAC+B9uSYcm+GjN3UYJjuun19GqYtK1bAFJ0KECXyfsgIDwH1MTzxbTxzJpZUbWLw8s0jcwCU06MWZj6cgnxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260409.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260409.1.tgz",
+      "integrity": "sha512-QIoNq5cgmn1ko8qlngmgZLXQr2KglrjvIwVFOyJI3rbIpt8631n/YMzHPiOWgt38Cb6tcni8fXOzkcvIX2lBDg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260409.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260409.1.tgz",
+      "integrity": "sha512-HJGBMTfPDb0GCjwdxWFx63wS20TYDVmtOuA5KVri/CiFnit71y++kmseVmemjsgLFFIzoEAuFG/xUh1FJLo6tg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260409.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260409.1.tgz",
+      "integrity": "sha512-GttFO0+TvE0rJNQbDlxC6kq2Q7uFxoZRo74Z9d/trUrLgA14HEVTTXobYyiWrDZ9Qp2W5KN1CrXQXiko0zE38Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260702.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
+      "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "2.0.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
+      "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-wasm32/node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@inanimate/resident": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@inanimate/resident/-/resident-0.1.1.tgz",
+      "integrity": "sha512-RTz//pX2Q2IFqeSx5ToJtbgWKaQRCh6yjHt8u41w1FrksLRUoBGJ1r+zoO3Ns/12D2EJaPzYZMAItu8PotVbog==",
+      "license": "MIT",
+      "peerDependencies": {
+        "agents": "^0.10.1"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
+      "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.142.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.142.0.tgz",
+      "integrity": "sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.1.tgz",
+      "integrity": "sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.1.tgz",
+      "integrity": "sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.1.tgz",
+      "integrity": "sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.1.tgz",
+      "integrity": "sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.1.tgz",
+      "integrity": "sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.1.tgz",
+      "integrity": "sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.1.tgz",
+      "integrity": "sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.1.tgz",
+      "integrity": "sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.1.tgz",
+      "integrity": "sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.1.tgz",
+      "integrity": "sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.1.tgz",
+      "integrity": "sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.1.tgz",
+      "integrity": "sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.2.1.tgz",
+      "integrity": "sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/core": "2.0.0-alpha.3",
+        "@emnapi/runtime": "2.0.0-alpha.3",
+        "@napi-rs/wasm-runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.1.tgz",
+      "integrity": "sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.1.tgz",
+      "integrity": "sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
+      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "license": "MIT"
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agents": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/agents/-/agents-0.10.2.tgz",
+      "integrity": "sha512-zltFKKENDClZgIJB7aRneI8tRpnCbMbP4RGPh4t8OgqKHomxUNZJEqMrjcgwP/0FX1W9GGrrLJVo9Ez2ibHVvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-proposal-decorators": "^7.29.0",
+        "@cfworker/json-schema": "^4.1.1",
+        "@modelcontextprotocol/sdk": "1.29.0",
+        "@rolldown/plugin-babel": "^0.2.3",
+        "cron-schedule": "^6.0.0",
+        "json-schema": "^0.4.0",
+        "json-schema-to-typescript": "^15.0.4",
+        "mimetext": "^3.0.28",
+        "nanoid": "^5.1.7",
+        "partyserver": "^0.4.1",
+        "partysocket": "1.1.16",
+        "picomatch": "^4.0.4",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "agents": "dist/cli/index.js"
+      },
+      "peerDependencies": {
+        "@ai-sdk/openai": "^3.0.0",
+        "@ai-sdk/react": "^3.0.0",
+        "@cloudflare/ai-chat": "^0.4.2",
+        "@cloudflare/codemode": "^0.3.4",
+        "@x402/core": "^2.0.0",
+        "@x402/evm": "^2.0.0",
+        "ai": "^6.0.0",
+        "react": "^19.0.0",
+        "viem": ">=2.0.0",
+        "vite": ">=6.0.0 <9.0.0",
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@ai-sdk/openai": {
+          "optional": true
+        },
+        "@ai-sdk/react": {
+          "optional": true
+        },
+        "@cloudflare/ai-chat": {
+          "optional": true
+        },
+        "@cloudflare/codemode": {
+          "optional": true
+        },
+        "@x402/core": {
+          "optional": true
+        },
+        "@x402/evm": {
+          "optional": true
+        },
+        "viem": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agents/node_modules/@rolldown/plugin-babel": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/plugin-babel/-/plugin-babel-0.2.3.tgz",
+      "integrity": "sha512-+zEk16yGlz1F9STiRr6uG9hmIXb6nprjLczV/htGptYuLoCuxb+itZ03RKCEeOhBpDDd1NU7qF6x1VLMUp62bw==",
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=22.12.0 || ^24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.29.0 || ^8.0.0-rc.1",
+        "@babel/plugin-transform-runtime": "^7.29.0 || ^8.0.0-rc.1",
+        "@babel/runtime": "^7.27.0 || ^8.0.0-rc.1",
+        "rolldown": "^1.0.0-rc.5",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/plugin-transform-runtime": {
+          "optional": true
+        },
+        "@babel/runtime": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.238",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.238.tgz",
+      "integrity": "sha512-XBIrxDzOrUAOqf+mkvzpOY67SRJoa5X99iMGAuCIcsey302+QW4AWpAJIyRuE3jJxmslWO4K3ToSeBUl1DeguA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.160",
+        "@ai-sdk/provider": "3.0.14",
+        "@ai-sdk/provider-utils": "4.0.41",
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.8.tgz",
+      "integrity": "sha512-zAgkquC2WYF0PIc6XbNYkA2uuxxFavzgmX61R+dHDUa558V8Ejf8ozTZFR6QzM24RWu4kBcRkhJ5kpz77j9fnQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0",
+      "peer": true
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/core-js-pure": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+      "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cron-schedule": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cron-schedule/-/cron-schedule-6.0.0.tgz",
+      "integrity": "sha512-BoZaseYGXOo5j5HUwTaegIog3JJbuH4BbrY9A1ArLjXpy+RWb3mV28F/9Gv1dDA7E2L8kngWva4NWisnLTyfgQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.399",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.399.tgz",
+      "integrity": "sha512-lEcqhErbHjXRvd41rnWLpzbyU/IXfIYo7QwaFWmxGeLiLyY2TBCdHnWY88vB+p3ubnihRypDm66panXl7TylLA==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-polyfill": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/event-target-polyfill/-/event-target-polyfill-0.0.4.tgz",
+      "integrity": "sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ==",
+      "license": "MIT"
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
+      "integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.32",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
+      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.5.tgz",
+      "integrity": "sha512-2E5L2yRp03FnwreJLJX8/r7mHiZICCf8kG7fAsTWkSQTDAcc46NIZoQLKy+EJ8sPoJlxyS4OQR5H70LjIZZlIQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-base64": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.9.2.tgz",
+      "integrity": "sha512-6zayE8QlUdiweYI6cETD/XBSqFcoCUlufn/29PJR99r82x1yDnIprRca0YvAYpAW+ez0GuQkVBC6xG5QkD7OjA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-to-typescript": {
+      "version": "15.0.4",
+      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-15.0.4.tgz",
+      "integrity": "sha512-Su9oK8DR4xCmDsLlyvadkXzX6+GGXJpbhwoLtOGArAG61dvbW4YQmSEno2y66ahpIdmLMg6YUf/QHLgiwvkrHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^11.5.5",
+        "@types/json-schema": "^7.0.15",
+        "@types/lodash": "^4.17.7",
+        "is-glob": "^4.0.3",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.8",
+        "prettier": "^3.2.5",
+        "tinyglobby": "^0.2.9"
+      },
+      "bin": {
+        "json2ts": "dist/src/cli.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luaparse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/luaparse/-/luaparse-0.3.1.tgz",
+      "integrity": "sha512-b21h2bFEbtGXmVqguHogbyrMAA0wOHyp9u/rx+w6Yc9pW1t9YjhGUsp87lYcp7pFRqSWN/PhFkrdIqKEUzRjjQ==",
+      "license": "MIT",
+      "bin": {
+        "luaparse": "bin/luaparse"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mimetext": {
+      "version": "3.0.28",
+      "resolved": "https://registry.npmjs.org/mimetext/-/mimetext-3.0.28.tgz",
+      "integrity": "sha512-eQXpbNrtxLCjUtiVbR/qR09dbPgZ2o+KR1uA7QKqGhbn8QV7HIL16mXXsobBL4/8TqoYh1us31kfz+dNfCev9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@babel/runtime-corejs3": "^7.26.0",
+        "js-base64": "^3.7.7",
+        "mime-types": "^2.1.35"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://patreon.com/muratgozel"
+      }
+    },
+    "node_modules/mimetext/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimetext/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260409.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260409.0.tgz",
+      "integrity": "sha512-ayl6To4av0YuXsSivGgWLj+Ug8xZ0Qz3sGV8+Ok2LhNVl6m8m5ktEBM3LX9iT9MtLZRJwBlJrKcraNs/DlZQfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "^0.34.5",
+        "undici": "7.24.4",
+        "workerd": "1.20260409.1",
+        "ws": "8.18.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/miniflare/node_modules/undici": {
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/partyserver": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/partyserver/-/partyserver-0.4.1.tgz",
+      "integrity": "sha512-StSs0oY8RmTxjGNil7VbCG4gnTN+4rYX20fiUIItAxTPpr/5rPDZT6PIvMROkk9M1Gn7GzE1wuQXwhxceaGhXA==",
+      "license": "ISC",
+      "dependencies": {
+        "nanoid": "^5.1.6"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20240729.0"
+      }
+    },
+    "node_modules/partysocket": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.16.tgz",
+      "integrity": "sha512-d7xFv+ZC7x0p/DAHWJ5FhxQhimIx+ucyZY+kxL0cKddLBmK9c4p2tEA/L+dOOrWm6EYrRwrBjKQV0uSzOY9x1w==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-polyfill": "^0.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.1.tgz",
+      "integrity": "sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@oxc-project/types": "=0.142.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.1",
+        "@rolldown/binding-darwin-arm64": "1.2.1",
+        "@rolldown/binding-darwin-x64": "1.2.1",
+        "@rolldown/binding-freebsd-x64": "1.2.1",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.1",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.1",
+        "@rolldown/binding-linux-arm64-musl": "1.2.1",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.1",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.1",
+        "@rolldown/binding-linux-x64-gnu": "1.2.1",
+        "@rolldown/binding-linux-x64-musl": "1.2.1",
+        "@rolldown/binding-openharmony-arm64": "1.2.1",
+        "@rolldown/binding-wasm32-wasi": "1.2.1",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.1",
+        "@rolldown/binding-win32-x64-msvc": "1.2.1"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/sharp/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260409.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260409.1.tgz",
+      "integrity": "sha512-kuWP20fAaqaLBqLbvUfY9nCF6c3C78L60G9lS6eVwBf+v8trVFIsAdLB/FtrnKm7vgVvpDzvFAfB80VIiVj95w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260409.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260409.1",
+        "@cloudflare/workerd-linux-64": "1.20260409.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260409.1",
+        "@cloudflare/workerd-windows-64": "1.20260409.1"
+      }
+    },
+    "node_modules/workers-ai-provider": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/workers-ai-provider/-/workers-ai-provider-3.3.1.tgz",
+      "integrity": "sha512-vArwnmiAxQQF1clsXJd9ADn1xK9YUZVxE4umaMhrdsxM2kucxP430LfaoH4rn0AfoqtnuH3bfRhW1ak0r1x/8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@ai-sdk/anthropic": "^3.0.0",
+        "@ai-sdk/google": "^3.0.0",
+        "@ai-sdk/openai": "^3.0.0",
+        "@ai-sdk/provider": "^3.0.0",
+        "ai": "^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@ai-sdk/anthropic": {
+          "optional": true
+        },
+        "@ai-sdk/google": {
+          "optional": true
+        },
+        "@ai-sdk/openai": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.81.1",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.81.1.tgz",
+      "integrity": "sha512-fppPXi+W2KJ5bx1zxdUYe1e7CHj5cWPFVBPXy8hSMZhrHeIojMe3ozAktAOw1voVuQjXzbZJf/GVKyVeSjbF8w==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.4.2",
+        "@cloudflare/unenv-preset": "2.16.0",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260409.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260409.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=20.3.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260409.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/yargs": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+      "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^8.2.1",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/youch/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/examples/m5stick-arc/server/package.json
+++ b/examples/m5stick-arc/server/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "m5stick-arc-server",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Cloudflare Worker running the arc agent loop: relays Resident devices, answers arc:ask events with inference via AI Gateway, and serves a live viewer.",
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.94",
+    "@inanimate/resident": "^0.1.0",
+    "agents": "^0.10.1",
+    "ai": "^6.0.220",
+    "luaparse": "^0.3.1",
+    "workers-ai-provider": "^3.3.1",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260411.1",
+    "typescript": "^6.0.2",
+    "wrangler": "4.81.1"
+  }
+}

--- a/examples/m5stick-arc/server/src/viewer.ts
+++ b/examples/m5stick-arc/server/src/viewer.ts
@@ -1,0 +1,134 @@
+/** Live viewer for the arc loop: mirror, message stream, remote intents. */
+export function viewerHtml(deviceId: string): string {
+  return `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>arc · ${deviceId}</title>
+<style>
+  :root { color-scheme: dark; }
+  body { font: 14px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
+         background: #101014; color: #e6e6ea; margin: 0; padding: 24px; }
+  h1 { font-size: 16px; font-weight: 600; margin: 0 0 4px; }
+  h1 small { color: #8a8a94; font-weight: 400; }
+  #status { display: inline-block; width: 9px; height: 9px; border-radius: 50%;
+            background: #555; margin-right: 8px; }
+  #status.on { background: #4ade80; }
+  .row { display: flex; gap: 20px; margin-top: 18px; align-items: flex-start; }
+  .panel { background: #17171d; border: 1px solid #26262e; border-radius: 8px;
+           padding: 14px 16px; }
+  #controls button { font: inherit; background: #26262e; color: #e6e6ea;
+    border: 1px solid #3a3a44; border-radius: 6px; padding: 6px 14px;
+    margin: 0 8px 8px 0; cursor: pointer; }
+  #controls button:hover { background: #32323c; }
+  #controls button.primary { background: #2b4a8f; border-color: #3c5ca8; }
+  #mirror { min-width: 260px; }
+  #mirror table { border-collapse: collapse; }
+  #mirror td { padding: 2px 10px 2px 0; vertical-align: top; }
+  #mirror td:first-child { color: #8a8a94; }
+  #pending { color: #fbbf24; display: none; }
+  #log { flex: 1; max-height: 70vh; overflow-y: auto; }
+  .m { padding: 3px 0; border-bottom: 1px solid #1e1e26; word-break: break-all; }
+  .m .dir { display: inline-block; width: 3.5em; color: #8a8a94; }
+  .m.up .dir { color: #4ade80; }
+  .m.down .dir { color: #60a5fa; }
+  .m .ty { color: #fbbf24; }
+  .m .body { color: #b9b9c2; }
+  .lat { color: #f472b6; }
+</style>
+</head>
+<body>
+<h1><span id="status"></span>arc <small>device ${deviceId}</small></h1>
+<div id="controls" class="panel">
+  <button class="primary" onclick="push()">Push adventure app</button>
+  <button onclick="intent('choose_a')">Choose A</button>
+  <button onclick="intent('choose_b')">Choose B</button>
+  <button onclick="intent('remix')">Remix look (shake)</button>
+  <button onclick="intent('arc:probe')">Probe</button>
+  <span id="pending">thinking…</span>
+</div>
+<div class="row">
+  <div id="mirror" class="panel">
+    <div style="color:#8a8a94;margin-bottom:6px">device mirror (arc:state)</div>
+    <table id="mirrorTable"><tr><td colspan="2">—</td></tr></table>
+  </div>
+  <div id="log" class="panel"></div>
+</div>
+<script>
+  var deviceId = ${JSON.stringify(deviceId)};
+  var base = "/devices/" + deviceId;
+  var log = document.getElementById("log");
+  var askStarted = {};
+
+  function line(cls, dir, type, body, extra) {
+    var div = document.createElement("div");
+    div.className = "m " + cls;
+    div.innerHTML = '<span class="dir">' + dir + '</span><span class="ty">' +
+      type + '</span> <span class="body"></span>' + (extra || "");
+    div.querySelector(".body").textContent = body;
+    log.prepend(div);
+    while (log.children.length > 200) log.removeChild(log.lastChild);
+  }
+
+  function showMirror(data) {
+    var t = document.getElementById("mirrorTable");
+    t.innerHTML = "";
+    Object.keys(data).sort().forEach(function (k) {
+      var tr = document.createElement("tr");
+      var td1 = document.createElement("td"); td1.textContent = k;
+      var td2 = document.createElement("td"); td2.textContent = data[k];
+      tr.appendChild(td1); tr.appendChild(td2); t.appendChild(tr);
+    });
+  }
+
+  function handle(m) {
+    if (m.type === "status") {
+      document.getElementById("status").className = m.deviceConnected ? "on" : "";
+      return;
+    }
+    var dir = m.dir, msg = m.msg;
+    if (!msg) { dir = "down"; msg = m; }   // raw /send echo from the relay
+    var type = (msg.channel ? msg.channel + "/" : "") + (msg.type || "?");
+    var body = JSON.stringify(msg.data !== undefined ? msg.data : msg);
+    var extra = "";
+    if (msg.type === "arc:ask" && msg.data) askStarted[msg.data.id] = Date.now();
+    if (msg.type === "arc:reply" && msg.data && askStarted[msg.data.id]) {
+      extra = ' <span class="lat">' + (Date.now() - askStarted[msg.data.id]) + 'ms</span>';
+      delete askStarted[msg.data.id];
+    }
+    document.getElementById("pending").style.display =
+      Object.keys(askStarted).length ? "inline" : "none";
+    if (msg.channel === "app" && msg.type === "arc:state") showMirror(msg.data || {});
+    line(dir === "up" ? "up" : "down", dir === "up" ? "dev →" : "→ dev", type, body, extra);
+  }
+
+  function connect() {
+    var ws = new WebSocket(
+      (location.protocol === "https:" ? "wss://" : "ws://") + location.host +
+      base + "?monitor=1");
+    ws.onmessage = function (e) {
+      if (typeof e.data !== "string") return;
+      try { handle(JSON.parse(e.data)); } catch (_) {}
+    };
+    ws.onclose = function () { setTimeout(connect, 2000); };
+  }
+  connect();
+
+  function push() {
+    fetch(base + "/arc/push", { method: "POST" })
+      .then(function (r) { return r.text(); })
+      .then(function (t) { line("down", "→ dev", "arc/push", t); });
+  }
+  function intent(name) {
+    fetch(base + "/send", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ channel: "app", type: name, from: "viewer",
+                             nonce: Math.random().toString(36).slice(2, 10) }),
+    });
+  }
+</script>
+</body>
+</html>`
+}

--- a/examples/m5stick-arc/server/src/worker.ts
+++ b/examples/m5stick-arc/server/src/worker.ts
@@ -1,0 +1,355 @@
+import { DeviceAgent, routeDeviceRequest } from "@inanimate/resident/cloudflare"
+import type { Connection, WSMessage } from "agents"
+import { generateObject, generateText } from "ai"
+import { createGatewayProvider } from "workers-ai-provider/gateway"
+import { createAnthropic } from "@ai-sdk/anthropic"
+import { z } from "zod"
+import luaparse from "luaparse"
+import arcLua from "../../app/arc.lua"
+import adventureLua from "../../app/adventure.lua"
+import { viewerHtml } from "./viewer"
+
+/**
+ * The agent side of the arc loop (see spikes/arc/DESIGN.md):
+ *
+ *   reflex   — runs on the device (the shipped arc generation)
+ *   response — arc:ask events land here and are answered with inference
+ *   revision — POST /arc/push ships a (re)generation to the device
+ *
+ * Inference goes through Cloudflare AI Gateway with BYOK: the gateway holds
+ * the Anthropic key, so this worker carries no model-provider secret.
+ */
+
+// Fast tier: story turns are latency-sensitive and narrow.
+const ASK_MODEL = "claude-haiku-4-5-20251001"
+// Code tier: remixes write Lua — rarer, worth a stronger model.
+const REMIX_MODEL = "claude-sonnet-5"
+
+// Must match the seed store in app/adventure.lua so the story history starts
+// at the scene the device is actually showing.
+const INTRO = {
+  text: "You wake in a moonlit orchard. A lantern glows by the gate, and something rustles in the long grass.",
+  a: "Take the lantern",
+  b: "Follow the rustle",
+}
+
+// The device's incoming-event data buffer is 256 bytes of serialized JSON —
+// the reply MUST fit or it is truncated mid-JSON and dropped by the app.
+const REPLY_BUDGET = 240
+
+const SceneSchema = z.object({
+  text: z.string().describe(
+    "The next story beat, second person, present tense, max 100 characters. Evocative, concrete, no choice text here."),
+  a: z.string().describe("Label for choice A, max 16 characters, imperative"),
+  b: z.string().describe("Label for choice B, max 16 characters, imperative"),
+})
+
+const STORY_SYSTEM = `You are the narrator of a tiny choose-your-own-adventure running on a 240x135 pixel badge. Gentle folk-tale strangeness; PG; keep momentum — every beat changes the situation. The reader carries a lantern; each turn includes "tilt" (-1..1), how the lantern is held — let where the light falls subtly shape what is revealed. HARD LIMITS: text <= 100 characters, each choice label <= 16 characters (labels are cut off past that, so end them cleanly). Never mention the limits or the tilt.`
+
+const VIEW_SYSTEM = `You design the ENTIRE look of a tiny 240x135 pixel story device by writing a Lua chunk. Output ONLY Lua code — no markdown fences, no commentary. The chunk must have exactly this shape:
+
+arc.view(function()
+  -- (optional locals)
+  return <widget>
+end)
+
+Widgets are plain Lua tables:
+ui.col{ pad=N, gap=N, align="start"|"center", child1, child2, ... }   vertical stack
+ui.row{ ... }                                                          horizontal stack
+ui.label{ text=s, size=1|2|3, color=c }        one line; 6*size px per char, 8*size px tall
+ui.text{ text=s, size=1, w=228, color=c }      word-wrapped block
+ui.rect{ w=N, h=N, color=c, fill=true|false }
+ui.bar{ value=0..1, w=N, h=N, color=c }
+ui.space{ w=N, h=N }
+ui.canvas{ w=N, h=N, draw=function(x, y) ... end }   free drawing at offset (x,y):
+  screen.fill_rect(x,y,w,h,r,g,b)  screen.rect(...)  screen.line(x0,y0,x1,y1,r,g,b)
+  screen.triangle(...)  screen.fill_triangle(x0,y0,x1,y1,x2,y2,r,g,b)  screen.pixel(x,y,r,g,b)
+Colors c: "white"|"gray"|"dim"|"red"|"green"|"blue"|"amber"|"cyan"|"magenta" or {r,g,b} (0-255).
+Conditional child: cond and widget or false.
+
+Readable globals:
+  S.text (current story beat), S.a and S.b (choice labels), S.scene (number)
+  TILT.x, TILT.y  (≈ -1..1, live accelerometer, updates 10x/second — parallax, sway, a glow that follows the hand)
+  arc.pending("turn")  falsy when idle; while the next beat is being written it returns the ask payload table — p.choice is "a" or "b". ALWAYS use this to visibly confirm which option the reader picked (highlight it, dim the other, echo it) with your own waiting microcopy (never the word "Thinking"). The pause must confirm the choice, not just say "busy".
+  arc.pending("remix") truthy while a new look is being designed
+  arc.dots(n)  animated 1..n counter for motion
+  sin cos floor abs min max fract are global functions
+
+The runtime always draws three small amber activity dots in the bottom-right
+corner (the last ~8px) while the agent is working — keep that corner clear.
+Your own waiting state is in addition to the dots, not a replacement.
+
+HARD RULES:
+- Everything fits in 240x135 with >= 6px bottom margin. Story text is ALWAYS ui.text with size=1 and w <= 228 (it can be 140 chars — plan for 4 wrapped lines).
+- S.a and S.b must be clearly visible and clearly marked as the two buttons (A/B).
+- <= 45 lines and <= 2200 characters total — prefer a few strong decorative elements over many tiny ones. No require/os/io/load/dofile/goto, no while or repeat loops.
+- Be bold: new palette, new composition, decoration, motion. Do not imitate the previous look.`
+
+type Turn = { choice?: string; text: string; a: string; b: string }
+
+export class ArcAgent extends DeviceAgent<Env> {
+  async onMessage(connection: Connection, data: WSMessage): Promise<void> {
+    await super.onMessage(connection, data)
+    if (typeof data !== "string") return
+    let msg: any
+    try { msg = JSON.parse(data) } catch { return }
+    this.toMonitors({ dir: "up", t: Date.now(), msg })
+
+    if (msg?.channel !== "app") return
+    if (msg.type === "arc:ask") {
+      await this.answerAsk(msg.data ?? {})
+    } else if (msg.type === "arc:state") {
+      await this.ctx.storage.put("mirror", msg.data ?? {})
+    }
+    // arc:intent needs no handling here — it is the transcript, already
+    // echoed to monitors above. A fuller agent would accumulate it as context.
+  }
+
+  async onRequest(request: Request): Promise<Response> {
+    const url = new URL(request.url)
+    const subpath = url.pathname.replace(/^\/devices\/[^/]+/, "")
+    if ((subpath === "" || subpath === "/") && request.method === "GET") {
+      return new Response(viewerHtml(this.name), {
+        headers: { "Content-Type": "text/html; charset=utf-8" },
+      })
+    }
+    if (subpath === "/arc/push" && request.method === "POST") {
+      return this.pushGeneration({ resetStory: true, resetLook: true })
+    }
+    if (subpath === "/arc/remix" && request.method === "POST") {
+      // Same code path as the device's shake → arc:ask remix, but surfaced
+      // over HTTP so failures come back as text instead of a DO reset.
+      try {
+        await this.remixLook({ id: 0 })
+        const debug = (await this.ctx.storage.get<string[]>("remixDebug")) ?? []
+        return Response.json({ ok: true, debug })
+      } catch (err: any) {
+        console.error("[arc] remix failed:", err)
+        return new Response(`remix failed: ${err?.stack ?? err}`, { status: 500 })
+      }
+    }
+    return super.onRequest(request)
+  }
+
+  /** Revision loop: ship runtime + logic + the current (possibly
+   *  model-written) look as one app. */
+  private async pushGeneration(opts: { resetStory: boolean; resetLook?: boolean }): Promise<Response> {
+    const devices = Array.from(this.getConnections("device"))
+    if (devices.length === 0) {
+      return new Response("Device not connected", { status: 503 })
+    }
+    const gen = "g" + Date.now().toString(36)
+    if (opts.resetLook) await this.ctx.storage.delete("viewChunk")
+    const viewChunk = (await this.ctx.storage.get<string>("viewChunk")) ?? ""
+
+    // Carry the story across the generation swap by baking the current
+    // scene into the pushed code — the new app boots already mid-story, no
+    // intro flash, no hydrate round-trip to race. (JSON string literals are
+    // valid Lua strings for our payloads: no \uXXXX escapes in this text.)
+    let carry = ""
+    if (!opts.resetStory) {
+      const story = (await this.ctx.storage.get<Turn[]>("story")) ?? [{ ...INTRO }]
+      const cur = story[story.length - 1]
+      carry =
+        `\nS.text = ${JSON.stringify(cur.text)}\nS.a = ${JSON.stringify(cur.a)}` +
+        `\nS.b = ${JSON.stringify(cur.b)}\nS.scene = ${story.length}\n`
+    }
+
+    const code =
+      `arc = { _gen = ${JSON.stringify(gen)} }\n${arcLua}\n${adventureLua}\n${viewChunk}${carry}`
+    await this.ctx.storage.put("gen", gen)
+    if (opts.resetStory) {
+      await this.ctx.storage.put("story", [{ ...INTRO }] satisfies Turn[])
+    }
+    this.sendToDevice({
+      channel: "system",
+      type: "app",
+      code,
+      description: "arc adventure",
+    })
+    console.log(`[arc] pushed generation ${gen} (${code.length} bytes, remixed look: ${!!viewChunk})`)
+    return Response.json({ ok: true, gen, bytes: code.length, remixed: !!viewChunk })
+  }
+
+  /** Response loop: answer an arc:ask with inference through the gateway. */
+  private async answerAsk(d: any): Promise<void> {
+    const gen = await this.ctx.storage.get<string>("gen")
+    if (gen && d.gen && d.gen !== gen) {
+      console.log(`[arc] dropping ask for stale generation ${d.gen} (current ${gen})`)
+      return
+    }
+    if (d.ask === "remix") return this.remixLook(d)
+
+    const story = (await this.ctx.storage.get<Turn[]>("story")) ?? [{ ...INTRO }]
+    const t0 = Date.now()
+
+    const transcript = story
+      .map((s) => (s.choice ? `[chose: ${s.choice}]\n${s.text}` : s.text))
+      .join("\n")
+    const tilt = typeof d.tilt === "number" ? ` (lantern tilt: ${d.tilt})` : ""
+    const prompt = `Story so far:\n${transcript}\n\nThe reader chose: "${this.choiceLabel(story, d.choice)}"${tilt}. Continue the story.`
+
+    let scene: z.infer<typeof SceneSchema>
+    try {
+      const model = createGatewayProvider(createAnthropic, {
+        binding: this.env.AI,
+        gateway: this.env.CLOUDFLARE_AIG_ID,
+      })(ASK_MODEL)
+      const { object } = await generateObject({
+        model,
+        schema: SceneSchema,
+        system: STORY_SYSTEM,
+        prompt,
+        maxOutputTokens: 300,
+      })
+      scene = object
+    } catch (err) {
+      console.error("[arc] inference failed:", err)
+      return // the device's shipped fallback covers us
+    }
+
+    const reply = this.fitReply({
+      id: d.id,
+      text: scene.text,
+      a: scene.a,
+      b: scene.b,
+      scene: story.length + 1,
+    })
+    this.sendToDevice({
+      channel: "app",
+      type: "arc:reply",
+      from: "arc-server",
+      nonce: crypto.randomUUID().slice(0, 8),
+      data: reply,
+    })
+    console.log(`[arc] answered ask ${d.id} (${d.ask}) in ${Date.now() - t0}ms: ${reply.text}`)
+
+    if (d.ask !== "recap") {
+      story.push({ choice: this.choiceLabel(story, d.choice), text: reply.text, a: reply.a, b: reply.b })
+      await this.ctx.storage.put("story", story.slice(-12))
+    }
+  }
+
+  /**
+   * Revision loop, model-authored: have a model write a brand-new view
+   * function (the whole look of the device — layout, palette, decoration,
+   * its own waiting-state microcopy), syntax-check it, splice it into the
+   * generation, push, and re-hydrate the story so play continues seamlessly.
+   */
+  private async remixLook(d: any): Promise<void> {
+    const t0 = Date.now()
+    const prev = (await this.ctx.storage.get<string>("viewChunk")) ?? "(the shipped default look)"
+    const story = (await this.ctx.storage.get<Turn[]>("story")) ?? [{ ...INTRO }]
+    const current = story[story.length - 1]
+
+    const model = createGatewayProvider(createAnthropic, {
+      binding: this.env.AI,
+      gateway: this.env.CLOUDFLARE_AIG_ID,
+    })(REMIX_MODEL)
+
+    let chunk: string | null = null
+    let feedback = ""
+    const debug: string[] = []
+    for (let attempt = 0; attempt < 2 && !chunk; attempt++) {
+      try {
+        const { text } = await generateText({
+          model,
+          system: VIEW_SYSTEM,
+          prompt:
+            `Previous look:\n${prev}\n\nCurrent scene for reference: text=${JSON.stringify(current.text)} a=${JSON.stringify(current.a)} b=${JSON.stringify(current.b)} scene=${story.length}\n\nDesign a completely different look.${feedback}`,
+          maxOutputTokens: 3500,
+        })
+        const candidate = text.replace(/^```(lua)?\s*/m, "").replace(/```\s*$/m, "").trim()
+        const problem = this.vetViewChunk(candidate)
+        if (problem) {
+          console.warn(`[arc] remix attempt ${attempt} rejected: ${problem}`)
+          debug.push(`attempt ${attempt}: ${problem}\n---\n${candidate.slice(0, 800)}`)
+          feedback = `\n\nYour previous attempt was rejected: ${problem}. Try again, obeying the rules exactly.`
+        } else {
+          chunk = candidate
+        }
+      } catch (err: any) {
+        console.error("[arc] remix inference failed:", err)
+        debug.push(`attempt ${attempt} threw: ${err?.message ?? err}`)
+        break
+      }
+    }
+    await this.ctx.storage.put("remixDebug", debug)
+
+    if (!chunk) {
+      this.sendToDevice({
+        channel: "app", type: "arc:reply", from: "arc-server",
+        nonce: crypto.randomUUID().slice(0, 8),
+        data: { id: d.id, note: "the world resists change" },
+      })
+      return
+    }
+
+    await this.ctx.storage.put("viewChunk", chunk)
+    console.log(`[arc] remix accepted in ${Date.now() - t0}ms (${chunk.length} chars)`)
+    // Story state is baked into the pushed code (carry-over) — the new
+    // generation boots mid-story with the new look, seamlessly.
+    await this.pushGeneration({ resetStory: false })
+  }
+
+  /** Cheap static vetting for a model-written view chunk. */
+  private vetViewChunk(code: string): string | null {
+    const body = code.replace(/^\s*(--[^\n]*\n)+/, "")   // leading comments are fine
+    if (!/^arc\.view\(function\s*\(\)/.test(body)) return 'chunk must start with arc.view(function()'
+    if (code.length > 4000) return "too long"
+    if (/\b(require|os|io|load|dofile|loadstring|goto|while|repeat)\b/.test(code)) {
+      return "uses a banned construct (require/os/io/load/goto/while/repeat)"
+    }
+    try {
+      luaparse.parse(code, { luaVersion: "5.3" })
+    } catch (e: any) {
+      return `Lua syntax error: ${e?.message ?? e}`
+    }
+    return null
+  }
+
+  private choiceLabel(story: Turn[], choice: unknown): string {
+    const current = story[story.length - 1]
+    if (choice === "a") return current?.a ?? "A"
+    if (choice === "b") return current?.b ?? "B"
+    return String(choice ?? "?")
+  }
+
+  /** Trim to a word boundary — mid-word cuts read as glitches on the badge. */
+  private trimWords(s: string, max: number): string {
+    if (s.length <= max) return s
+    const cut = s.slice(0, max)
+    const sp = cut.lastIndexOf(" ")
+    return (sp > max / 2 ? cut.slice(0, sp) : cut).trim()
+  }
+
+  /** Trim fields until the serialized reply fits the device's event buffer. */
+  private fitReply<T extends { text: string; a: string; b: string }>(reply: T): T {
+    const fit = { ...reply, a: this.trimWords(reply.a, 18), b: this.trimWords(reply.b, 18) }
+    let max = 140
+    while (JSON.stringify(fit).length > REPLY_BUDGET && max > 20) {
+      max -= 10
+      fit.text = this.trimWords(fit.text, max)
+    }
+    return fit
+  }
+
+  private sendToDevice(obj: unknown): void {
+    const s = JSON.stringify(obj)
+    for (const conn of this.getConnections("device")) conn.send(s)
+    this.toMonitors({ dir: "down", t: Date.now(), msg: obj })
+  }
+
+  private toMonitors(obj: unknown): void {
+    const s = JSON.stringify(obj)
+    for (const m of this.getConnections("monitor")) m.send(s)
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env) {
+    const res = await routeDeviceRequest(request, env.ArcAgent)
+    if (res) return res
+    return new Response("Not found", { status: 404 })
+  },
+} satisfies ExportedHandler<Env>

--- a/examples/m5stick-arc/server/src/worker.ts
+++ b/examples/m5stick-arc/server/src/worker.ts
@@ -37,6 +37,17 @@ const INTRO = {
 // the reply MUST fit or it is truncated mid-JSON and dropped by the app.
 const REPLY_BUDGET = 240
 
+const ROUTE_SYSTEM = `You route a spoken utterance for a tiny story device. You are given the device's current program (Lua, using the arc framework), its live state, and what the user said. Decide:
+- action="intent" when the utterance clearly expresses one of the available intents. Read the program to understand what each intent means in context — e.g. an utterance close in meaning to one of the on-screen choices maps to that choice's intent. Judge by meaning, never by keywords.
+- action="turn" when it is story input no intent captures — an instruction, a question, an idea the narrator should weave into the next beat.
+- action="ignore" for noise, fragments, or things that are not input.`
+
+const RouteSchema = z.object({
+  action: z.enum(["intent", "turn", "ignore"]),
+  intent: z.string().optional().describe("when action=intent: the exact intent name to inject"),
+  reason: z.string().optional().describe("one short sentence"),
+})
+
 const SceneSchema = z.object({
   text: z.string().describe(
     "The next story beat, second person, present tense, max 100 characters. Evocative, concrete, no choice text here."),
@@ -73,6 +84,7 @@ Readable globals:
   arc.pending("turn")  falsy when idle; while the next beat is being written it returns the ask payload table — p.choice is "a" or "b". ALWAYS use this to visibly confirm which option the reader picked (highlight it, dim the other, echo it) with your own waiting microcopy (never the word "Thinking"). The pause must confirm the choice, not just say "busy".
   arc.pending("remix") truthy while a new look is being designed
   arc.dots(n)  animated 1..n counter for motion
+  S.voice  non-empty while the reader is speaking or was just heard (a listening prompt or a quoted transcript) — show it when present, subtly, near the bottom
   sin cos floor abs min max fract are global functions
 
 The runtime always draws three small amber activity dots in the bottom-right
@@ -87,13 +99,66 @@ HARD RULES:
 
 type Turn = { choice?: string; text: string; a: string; b: string }
 
+// PTT audio bounds: 16 kHz mono int16 PCM from the mic pump.
+const PCM_BYTES_PER_SEC = 16000 * 2
+const VOICE_MIN_BYTES = 0.4 * PCM_BYTES_PER_SEC
+const VOICE_MAX_BYTES = 15 * PCM_BYTES_PER_SEC
+
+function pcmToWav(pcm: Uint8Array, rate: number): Uint8Array {
+  const out = new Uint8Array(44 + pcm.length)
+  const dv = new DataView(out.buffer)
+  const str = (off: number, s: string) => { for (let i = 0; i < s.length; i++) out[off + i] = s.charCodeAt(i) }
+  str(0, "RIFF"); dv.setUint32(4, 36 + pcm.length, true); str(8, "WAVE")
+  str(12, "fmt "); dv.setUint32(16, 16, true); dv.setUint16(20, 1, true)
+  dv.setUint16(22, 1, true); dv.setUint32(24, rate, true)
+  dv.setUint32(28, rate * 2, true); dv.setUint16(32, 2, true); dv.setUint16(34, 16, true)
+  str(36, "data"); dv.setUint32(40, pcm.length, true)
+  out.set(pcm, 44)
+  return out
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = ""
+  const chunk = 0x8000
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk))
+  }
+  return btoa(binary)
+}
+
 export class ArcAgent extends DeviceAgent<Env> {
+  // In-memory PTT capture. Frames arrive every few ms while the button is
+  // held, so the DO stays hot for the whole recording; a hibernation between
+  // start and end would drop the take (acceptable at demo scale).
+  private audio: Uint8Array[] = []
+  private audioBytes = 0
+  private recording = false
+
   async onMessage(connection: Connection, data: WSMessage): Promise<void> {
     await super.onMessage(connection, data)
+    if (data instanceof ArrayBuffer) {
+      if (this.recording && this.audioBytes < VOICE_MAX_BYTES) {
+        this.audio.push(new Uint8Array(data.slice(0)))
+        this.audioBytes += data.byteLength
+      }
+      return
+    }
     if (typeof data !== "string") return
     let msg: any
     try { msg = JSON.parse(data) } catch { return }
     this.toMonitors({ dir: "up", t: Date.now(), msg })
+
+    if (msg?.channel === "system" && msg.type === "voice") {
+      if (msg.state === "start") {
+        this.recording = true
+        this.audio = []
+        this.audioBytes = 0
+      } else if (msg.state === "end") {
+        this.recording = false
+        await this.handleVoiceEnd()
+      }
+      return
+    }
 
     if (msg?.channel !== "app") return
     if (msg.type === "arc:ask") {
@@ -103,6 +168,99 @@ export class ArcAgent extends DeviceAgent<Env> {
     }
     // arc:intent needs no handling here — it is the transcript, already
     // echoed to monitors above. A fuller agent would accumulate it as context.
+  }
+
+  /**
+   * PTT release: transcribe the take with Workers AI whisper, confirm what
+   * was heard back to the device (the app shows it — local reassurance),
+   * then let a model decide what the words MEAN by reading the device's
+   * current program and state. Nothing about the mapping is hardcoded: an
+   * utterance near one of the on-screen choices becomes that choice's
+   * intent on the normal bus; free-form story input becomes the next beat.
+   */
+  private async handleVoiceEnd(): Promise<void> {
+    const total = this.audioBytes
+    const chunks = this.audio
+    this.audio = []
+    this.audioBytes = 0
+    if (total < VOICE_MIN_BYTES) {
+      console.log(`[arc] voice: take too short (${total} bytes), ignoring`)
+      return
+    }
+    const pcm = new Uint8Array(total)
+    let off = 0
+    for (const c of chunks) { pcm.set(c, off); off += c.length }
+
+    const t0 = Date.now()
+    let text = ""
+    try {
+      const res: any = await (this.env.AI as any).run(
+        "@cf/openai/whisper-large-v3-turbo",
+        { audio: bytesToBase64(pcmToWav(pcm, 16000)) },
+        { gateway: { id: this.env.CLOUDFLARE_AIG_ID } },
+      )
+      text = String(res?.text ?? "").trim()
+    } catch (err) {
+      console.error("[arc] whisper failed:", err)
+    }
+    console.log(`[arc] voice: ${(total / PCM_BYTES_PER_SEC).toFixed(1)}s -> ${JSON.stringify(text)} in ${Date.now() - t0}ms`)
+
+    // Confirm the transcript on-device even when empty — the app's "heard"
+    // handler shows it (or "(couldn't hear)") in place of the listening state.
+    this.sendToDevice({
+      channel: "app", type: "heard", from: "arc-server",
+      nonce: crypto.randomUUID().slice(0, 8),
+      data: { text: text.slice(0, 180) },
+    })
+    if (text) await this.routeUtterance(text)
+  }
+
+  private async routeUtterance(text: string): Promise<void> {
+    const mirror = (await this.ctx.storage.get<Record<string, unknown>>("mirror")) ?? {}
+    const intents = [...adventureLua.matchAll(/arc\.on\("([a-z_]+)"/g)]
+      .map((m) => m[1])
+      .filter((n) => n !== "ptt" && n !== "heard")
+    const model = createGatewayProvider(createAnthropic, {
+      binding: this.env.AI,
+      gateway: this.env.CLOUDFLARE_AIG_ID,
+    })(ASK_MODEL)
+    let route: z.infer<typeof RouteSchema>
+    try {
+      const { object } = await generateObject({
+        model, schema: RouteSchema, system: ROUTE_SYSTEM,
+        prompt:
+          `The device is running this program:\n\n${adventureLua}\n\n` +
+          `Its live state (the store):\n${JSON.stringify(mirror)}\n\n` +
+          `Available intents to inject: ${intents.join(", ")}\n\n` +
+          `The user held the talk button and said: ${JSON.stringify(text)}\n\nRoute it.`,
+        maxOutputTokens: 200,
+      })
+      route = object
+    } catch (err: any) {
+      console.error("[arc] voice routing failed:", err)
+      this.toMonitors({ dir: "down", t: Date.now(),
+        msg: { type: "voice:route", data: { text, error: String(err?.message ?? err).slice(0, 200) } } })
+      return
+    }
+    console.log(`[arc] voice route: ${JSON.stringify(route)}`)
+    this.toMonitors({ dir: "down", t: Date.now(), msg: { type: "voice:route", data: { text, ...route } } })
+
+    if (route.action === "intent" && route.intent && intents.includes(route.intent)) {
+      this.sendToDevice({
+        channel: "app", type: route.intent, from: "arc-server",
+        nonce: crypto.randomUUID().slice(0, 8),
+        data: { via: "voice" },
+      })
+    } else if (route.action === "turn") {
+      const beat = await this.nextBeat(`(spoken) ${JSON.stringify(text)}`)
+      if (beat) {
+        this.sendToDevice({
+          channel: "app", type: "arc:hydrate", from: "arc-server",
+          nonce: crypto.randomUUID().slice(0, 8),
+          data: beat,
+        })
+      }
+    }
   }
 
   async onRequest(request: Request): Promise<Response> {
@@ -182,12 +340,34 @@ export class ArcAgent extends DeviceAgent<Env> {
 
     const story = (await this.ctx.storage.get<Turn[]>("story")) ?? [{ ...INTRO }]
     const t0 = Date.now()
+    const beat = await this.nextBeat(this.choiceLabel(story, d.choice), d.tilt)
+    if (!beat) return // the device's shipped fallback covers us
 
+    this.sendToDevice({
+      channel: "app",
+      type: "arc:reply",
+      from: "arc-server",
+      nonce: crypto.randomUUID().slice(0, 8),
+      data: { id: d.id, ...beat },
+    })
+    console.log(`[arc] answered ask ${d.id} (${d.ask}) in ${Date.now() - t0}ms: ${beat.text}`)
+  }
+
+  /**
+   * Generate, fit, and record the next story beat for a "choice" — either a
+   * button choice's label or a free-form `(spoken) "..."` utterance. Shared
+   * by the ask path (reply) and the voice path (hydrate).
+   */
+  private async nextBeat(
+    choiceText: string,
+    tilt?: unknown,
+  ): Promise<{ text: string; a: string; b: string; scene: number } | null> {
+    const story = (await this.ctx.storage.get<Turn[]>("story")) ?? [{ ...INTRO }]
     const transcript = story
       .map((s) => (s.choice ? `[chose: ${s.choice}]\n${s.text}` : s.text))
       .join("\n")
-    const tilt = typeof d.tilt === "number" ? ` (lantern tilt: ${d.tilt})` : ""
-    const prompt = `Story so far:\n${transcript}\n\nThe reader chose: "${this.choiceLabel(story, d.choice)}"${tilt}. Continue the story.`
+    const tiltNote = typeof tilt === "number" ? ` (lantern tilt: ${tilt})` : ""
+    const prompt = `Story so far:\n${transcript}\n\nThe reader chose: "${choiceText}"${tiltNote}. Continue the story.`
 
     let scene: z.infer<typeof SceneSchema>
     try {
@@ -205,29 +385,18 @@ export class ArcAgent extends DeviceAgent<Env> {
       scene = object
     } catch (err) {
       console.error("[arc] inference failed:", err)
-      return // the device's shipped fallback covers us
+      return null
     }
 
-    const reply = this.fitReply({
-      id: d.id,
+    const beat = this.fitReply({
       text: scene.text,
       a: scene.a,
       b: scene.b,
       scene: story.length + 1,
     })
-    this.sendToDevice({
-      channel: "app",
-      type: "arc:reply",
-      from: "arc-server",
-      nonce: crypto.randomUUID().slice(0, 8),
-      data: reply,
-    })
-    console.log(`[arc] answered ask ${d.id} (${d.ask}) in ${Date.now() - t0}ms: ${reply.text}`)
-
-    if (d.ask !== "recap") {
-      story.push({ choice: this.choiceLabel(story, d.choice), text: reply.text, a: reply.a, b: reply.b })
-      await this.ctx.storage.put("story", story.slice(-12))
-    }
+    story.push({ choice: choiceText, text: beat.text, a: beat.a, b: beat.b })
+    await this.ctx.storage.put("story", story.slice(-12))
+    return beat
   }
 
   /**

--- a/examples/m5stick-arc/server/tsconfig.json
+++ b/examples/m5stick-arc/server/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src", "env.d.ts"]
+}

--- a/examples/m5stick-arc/server/wrangler.jsonc
+++ b/examples/m5stick-arc/server/wrangler.jsonc
@@ -1,0 +1,22 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "m5stick-arc",
+  "main": "src/worker.ts",
+  "compatibility_date": "2026-03-02",
+  "compatibility_flags": ["nodejs_compat"],
+  // Deploy with CLOUDFLARE_ACCOUNT_ID=<your account id> in the environment —
+  // the account id is deliberately not committed here.
+  "vars": {
+    // Name of the AI Gateway on your account. The gateway holds the Anthropic
+    // API key (BYOK) so this worker needs no model-provider secret.
+    "CLOUDFLARE_AIG_ID": "hawthorn-gateway"
+  },
+  "ai": { "binding": "AI", "remote": true },
+  "durable_objects": {
+    "bindings": [{ "name": "ArcAgent", "class_name": "ArcAgent" }]
+  },
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ArcAgent"] }],
+  // Bundle .lua sources as text modules (the arc runtime + the generation).
+  "rules": [{ "type": "Text", "globs": ["**/*.lua"], "fallthrough": true }],
+  "observability": { "enabled": true }
+}

--- a/spikes/arc/DESIGN.md
+++ b/spikes/arc/DESIGN.md
@@ -1,0 +1,576 @@
+# arc — a reactive framework for generative device UI
+
+**Status: spike.** Design + toy implementation. Nothing here is API-stable.
+
+arc is a framework for writing Resident apps where the app is not the product
+— the app is *the current output of an agent*. The agent generates behavior;
+the device executes it inside the human interaction loop; the device streams
+semantic events back; the agent revises. Apps must be equally writable by
+humans and by models, because over the life of a device they will be written
+by both, often interleaved.
+
+The name is from the reflex arc: when you touch a hot stove, your spinal cord
+withdraws your hand before the signal reaches your brain. The brain finds out
+afterwards, and decides what to do *next*. That is this architecture. The
+device runs reflexes; the agent is the brain; the wire between them is slow
+and that's fine, because the reflexes were shipped ahead of time.
+
+---
+
+## 1. Premise, and why the ideal case fails
+
+The ideal generative UI: every pixel, every buzzer tone, every fan-speed
+value is produced by inference on the fly, and every touch event and IMU
+sample streams back as tokens. The agent sits in a loop consuming raw input
+and emitting raw output. A device is a pure I/O surface for a model.
+
+This fails for two distinct reasons, and each failure points at a design
+principle:
+
+**Failure 1 — abstraction.** Humans and agents reason about *a button was
+tapped*, not *touch-down at (48,112), touch-up at (49,110), 80ms apart*. Raw
+I/O streams are the wrong altitude in both directions: pixel-pushing down,
+sample-streaming up. The fix is the one UI programming already knows — 
+components and events (React), streams with semantic operators (Rx), or on
+embedded, a widget library like LVGL. **Principle: the wire should carry
+meaning, not samples — in both directions.**
+
+**Failure 2 — latency.** The screen is one network hop, one context-gather,
+and one inference away from the model. Human interaction psychology needs
+~150ms for "instant". Inference is 1–10s on a good day. No amount of
+model speed fully closes this, because context-gathering (what's in the
+room? what did the user do this morning?) is itself slow. **Principle: the
+agent must ship behavior forward in time — code that covers the interaction
+envelope for the next seconds-to-hours — rather than answering each input.**
+
+The second principle is Cloudflare's codemode insight applied to devices:
+the agent loop shouldn't be tool-call → inference → tool-call; the agent
+writes small programs that collapse many steps into one artifact. Resident
+is already codemode for devices — Lua source pushed over the network *is*
+the collapsed program. arc is the question: what should those programs look
+like, so that generating, reading, and revising them is easy?
+
+A useful compression of the whole idea: **a program is cached inference.**
+The agent doesn't generate outputs; it generates the *function from inputs
+to outputs*, and the device evaluates that function at reflex speed.
+Regeneration is cache invalidation.
+
+## 2. The three loops
+
+Everything in arc is organized around three nested loops, distinguished by
+latency and by where the computation runs:
+
+| Loop | Latency | Runs | Mechanism |
+|------|---------|------|-----------|
+| **Reflex** | < 150 ms | on device | shipped handlers, recognizers, view function |
+| **Response** | 1–10 s | agent, per interaction | `ask` / reply — a hole in the shipped behavior, with a local fallback |
+| **Revision** | minutes–hours | agent, per regime | regenerate the program; hydrate state across the swap |
+
+The reflex loop is everything the shipped code can decide alone: toggle the
+stopwatch, play the click, move the cursor, animate the dots. The response
+loop is for interactions that *require* inference — the next sentence of the
+story, the answer to a question — and the framework's job is to make the
+seam ergonomic: instant local acknowledgment ("Thinking…"), then the reply
+arrives as data. The revision loop is the agent changing the policy itself:
+new activity, new mode, new UI — triggered by intent patterns (user seems
+bored), schedules (morning vs evening), or external context.
+
+A key property: **the agent participates at every loop, but only writes code
+at the outermost one.** In the response loop it sends data (a reply). In the
+reflex loop it isn't present at all — it was present earlier, when it wrote
+the handler.
+
+## 3. Core concepts
+
+### 3.1 Intents — one bus, both directions
+
+An **intent** is a named, semantic event: `toggle`, `choose{choice="a"}`,
+`shake`, `wake`. All behavior is intent handlers. Intents come from three
+sources and the handler cannot tell which:
+
+- **Recognizers** — on-device compressors from raw input to intents
+  (`arc.tap(0, "toggle")`, `arc.shake(2.0, "shake")`, `arc.idle(30000, "bored")`).
+- **Local code** — `arc.intent("reset")` from a timer or another handler.
+- **The agent** — any non-`arc:*` event arriving on the app channel is
+  injected as an intent.
+
+That last one matters: the agent is just another input device. It nudges the
+running UI at the same abstraction level as the user's thumb. A reminder,
+a mode switch, a "look alive" — all just intents, handled by shipped code.
+
+Every intent is also published upstream (rate-limit-respecting, see §6).
+This is the "token stream of inputs" from the premise, at the right
+altitude: the agent sees `choose{choice="a"}`, not accelerometer samples.
+
+### 3.2 Recognizers — the agent's sensory attention, as code
+
+Recognizers are the up-direction abstraction: parameterized, named
+compressors from the raw driver stream to intents. They are the Rx operator
+library (debounce, threshold, window) but *packaged and named*, because
+operator soup is exactly what humans misread and models miscompose.
+
+The generative twist: since the agent writes the program, **the agent
+chooses its own sensory bandwidth**. A sleep-tracking generation ships
+sensitive motion recognizers and publishes everything; a stopwatch ships
+button taps and publishes nearly nothing. Attention is code, revised per
+regime. (In the limit a recognizer could be a distilled model — wake-word
+style — running on-device. Same interface.)
+
+### 3.3 The store — one table, and it outlives the code
+
+All app state lives in a single store table (`s = arc.store{...}`). No
+component-local state, no closures-as-state. This is deliberately Elm, not
+React, and the reason is legibility: **the whole state of the device is one
+small serializable value.** That buys three things:
+
+1. The view can be a pure function of it.
+2. The device can publish it (the *mirror*, §3.6).
+3. It can survive regeneration (*hydration*): snapshot travels up; the
+   agent bakes current values into the next generation's `arc.store{...}`
+   defaults (or follows a load with `arc:hydrate`). The code is disposable;
+   the store is continuous. State belongs to the *session*, not to the
+   program — programs are cache entries.
+
+### 3.4 The view — data, not drawing
+
+`arc.view(fn)` registers a pure function returning a widget *tree of plain
+tables*: `ui.col{ ui.label{text="12:04", size=4}, ui.bar{value=0.3} }`.
+A dumb renderer lays it out and draws it via `screen.*` every tick
+(10 FPS full redraw — reconciliation is pointless when a full frame on a
+240×135 sprite is cheap; immediate-mode is simpler *and* more legible).
+
+View-as-data is what makes the UI generative, because it makes the UI
+*readable by the agent*: a framebuffer is illegible to a model at any
+reasonable token budget, but `{col: [label "PAUSED", label "00:34.2"]}` is a
+handful of tokens. The screen contents can literally appear in the agent's
+context. It also makes the render backend swappable: the same tree could
+target LVGL, an e-ink panel, or the three screens of a face (§9).
+
+Outputs generally come in three kinds, and the view is only one:
+
+- **View** — structured, discrete, redrawn: the screen tree(s).
+- **Bindings** — continuous scalars sampled every tick: fan speed, LED
+  brightness (`arc.every(100, function() fan.set(spd()) end)`).
+- **Effects** — one-shot, fired from handlers: `buzzer.beep`, `arc.play{...}`.
+
+### 3.5 Asks — Suspense for inference
+
+The flagship primitive. Inside any intent handler:
+
+```lua
+local r = arc.ask("turn", { choice = p.choice }, {
+  timeout_ms = 8000,
+  fallback   = { text = "The mist thickens..." },
+})
+s.text = r.text
+```
+
+`ask` publishes the question upstream, suspends the handler (it's a
+coroutine), and lets the reflex loop keep running — the view re-renders
+immediately, and `arc.pending("turn")` is true so the view can show its
+"Thinking…" state *within the 150ms budget*. When the reply event arrives
+(or the timeout fires), the handler resumes with the reply (or the
+fallback) and continues as if the call had been synchronous.
+
+This is React Suspense with the roles shifted: the hole is not "data still
+loading" but "decision not yet made", and the fallback is not a spinner
+component but whatever the generation chose to ship — microcopy, a rustle
+of leaves from the buzzer, a dimmed screen. Fallbacks are not optional
+decoration; the network *will* be slow sometimes, so the language makes
+the degraded path a required, named part of the construct.
+
+**System chrome: inference is never silent.** Whenever any ask is in
+flight the runtime itself draws a small pulsing indicator (three amber
+dots, bottom-right), regardless of what the view does — like a browser's
+loading spinner, it belongs to the platform, not the page. A generation
+can layer richer pending treatments on top (and the view-writing prompt
+encourages authored microcopy), but hiding agent activity requires an
+explicit opt-out (`arc.activity(false)`). The default matters: if silently
+running inference is the easiest thing to write, generated apps will do
+it, and the user loses the thread of what the device is doing.
+
+**The pending ask carries its payload.** `arc.pending(name)` returns the
+in-flight ask's payload table (truthy), not a bare boolean — so the view
+can *confirm the question* during the wait: highlight the option the user
+just chose, echo the query, dim the road not taken. This is optimistic-UI
+thinking adapted to the ask boundary: the local loop already knows what
+was asked, and a pause that confirms the choice reassures where a generic
+spinner merely stalls. (This came directly out of live use: "thinking" 
+alone doesn't tell you *what it heard*.)
+
+### 3.6 The mirror — the device as tokens
+
+The agent can only generate good behavior if it can see the device. arc
+maintains a compact snapshot — store contents, pending asks, generation id
+— published on init, on `arc:probe`, and (throttled) after store changes.
+Combined with the intent transcript and the current program source, the
+agent's context contains: *what the device can do* (device profile), *what
+it is currently doing* (the program — which the agent itself wrote, so
+reading it is re-reading its own plan), *what state it's in* (mirror), and
+*what the human has done* (intents). That is the entire loop made legible.
+
+### 3.7 Generations — programs as disposable policy
+
+A **generation** is one shipped program (Resident already names this:
+`generationId`). arc treats generations as cheap and disposable: the agent
+regenerates the whole L3 program (it's a few hundred tokens) rather than
+patching code. Data-level patches flow through the running generation
+(replies, hydrate, injected intents); behavior-level changes are a new
+generation. Every ask carries the generation id so late replies to a dead
+generation can be dropped (§6).
+
+### 3.8 Timelines
+
+Behavior spans time, so time is a primitive, not a library:
+`arc.after(ms, fn)`, `arc.every(ms, fn)`, `arc.tween{from,to,ms,ease}`,
+`arc.play{{freq,ms},...}`. Under the hood all of it is one scheduler on the
+tick. This is also what makes hours-scale generations writable: a morning
+briefing app is mostly timeline.
+
+## 4. Prior art, mapped
+
+| Source | What arc takes | What arc changes |
+|--------|----------------|------------------|
+| Elm architecture | single store, Msg≈intent, pure view | adds the oracle (`ask`) and cross-generation hydration |
+| React | declarative view, components-as-vocabulary | immediate-mode, no reconciliation, no component-local state |
+| Suspense | render-while-pending with fallback | the pending thing is *inference*, fallback is authored per-ask |
+| Rx / FRP | recognizers are operators (debounce, threshold, scan) | named & parameterized, not composed inline |
+| LVGL | the widget-vocabulary idea | widgets are data, not retained C objects; LVGL could be a *backend* |
+| Cloudflare codemode | agent ships programs, not calls | the program's *shape* is constrained so it stays legible/revisable |
+| Erlang hot swap | code replaced under a live system | state continuity via mirror+hydrate instead of process mailboxes |
+
+## 5. Alternatives considered
+
+**A. FRP-first (Rx everywhere).** Streams and operator composition as the
+whole language. Rejected: operator chains are the least readable artifact
+for both audiences (humans misread them; models miscompose them), and
+per-event allocation churn is hostile to a microcontroller GC. The operator
+*ideas* survive as recognizers.
+
+**B. Mini-React (components, local state, reconciliation).** Rejected:
+reconciliation buys nothing at 240×135@10FPS, and scattering state into
+components destroys the mirror and hydration — the two properties the
+agent loop depends on most.
+
+**C. Server-driven UI (ship JSON views + bindings, no code).** The safe,
+boring version: agent sends a declarative screen, device renders it.
+Rejected as the *foundation* because reflex logic needs real code (SDUI
+systems always sprout ad-hoc expression languages), but note that SDUI is
+the degenerate case of arc — a generation whose handlers are trivial. arc
+subsumes it.
+
+**D. A new textual DSL.** Rejected: agents already speak Lua fluently; the
+device already compiles Lua; the validator toolchain exists; and a compiled
+DSL breaks "the agent reads the running policy" unless it round-trips.
+arc is an embedded DSL — Lua tables and functions with strong conventions.
+
+**E. LVGL as the widget layer.** Deferred: it's the right thing for visual
+polish on bigger screens, but its imperative retained-object API is a bad
+*generative target* (illegible as data, stateful to drive from a sandbox).
+The right integration is LVGL as a render backend for the arc tree.
+
+## 6. Runtime architecture
+
+arc is layered; each layer has one owner:
+
+```
+L3  the generation        — written by the agent (or a human), per regime
+L2  device profile        — widget set + recognizers for this hardware (per DEVICE-SKILL)
+L1  arc runtime (arc.lua) — pure Lua, ~500 lines, same for every device
+L0  Resident sandbox      — C++ firmware (exists today, unchanged)
+```
+
+The server concatenates L1 (+L2) with the generation and pushes one `app`
+message. The agent only ever writes L3 — the runtime costs no tokens in the
+agent's output, only bytes on the wire.
+
+**Mapping to the sandbox.** arc.lua defines the three lifecycle globals
+itself; generations never do:
+
+- `init` — render first frame, publish hello snapshot.
+- `on_tick` — scheduler (timers, tweens, tones) → recognizer polling (IMU,
+  idle) → ask-timeout sweep → outbox drain → render.
+- `on_event` — `arc:*` types handled internally (reply/hydrate/probe);
+  `button` events feed tap recognizers; anything else is injected as an
+  intent. After dispatch, if the store changed, render immediately —
+  event delivery runs at main-loop rate, so input→pixel is well under the
+  150ms budget even though the tick is 100ms.
+
+**Wire protocol.** Everything rides the existing channel plane; no firmware
+changes needed.
+
+Up (data plane, `events.send` — flat tables, ≤256 bytes, 5/s bucket):
+
+| name | payload | when |
+|------|---------|------|
+| `arc:intent` | `{name, ...payload}` | every intent (through the outbox) |
+| `arc:ask` | `{ask, id, gen, ...payload}` | on `arc.ask` |
+| `arc:state` | `{gen, ...flattened store}` | init, probe, throttled after store changes |
+
+Down (app channel messages; `event.name` = type):
+
+| type | payload | effect |
+|------|---------|--------|
+| `arc:reply` | `{id, ...data}` | resume the suspended handler |
+| `arc:hydrate` | `{...}` | merge keys into the store |
+| `arc:probe` | `{}` | publish `arc:state` |
+| *anything else* | `{...}` | injected as an intent |
+
+**Budgets are a feature.** The 256-byte/5-per-second data plane forces
+exactly the semantic compression §1 argues for. The outbox retries on
+rate-limit (`events.send` returning false), drops oldest intents under
+pressure, never drops asks. Payloads that genuinely need more (audio, big
+state) belong on the system channel or the mic pump — out of scope here.
+
+**The generation race.** An ask can be in flight when a new generation
+loads; the reply would then arrive at a program that never asked it. Every
+ask carries `gen` (the server bakes `arc._gen = "<id>"` into the concat;
+core could expose `ctx.generation_id` later and remove the hack). The
+server drops replies addressed to a dead generation — and since the
+snapshot travels with the ask, it can usually answer the ask *into the new
+generation* instead (bake the answer into the regenerated code).
+
+## 7. The language, by example
+
+The complete stopwatch (reflex loop only — this runs with zero agent
+involvement after shipping):
+
+```lua
+local s = arc.store{ running = false, elapsed = 0 }
+
+arc.tap(0, "toggle")
+arc.tap(1, "reset")
+
+arc.on("toggle", function()
+  s.running = not s.running
+  buzzer.beep(s.running and 880 or 440, 40)
+end)
+
+arc.on("reset", function()
+  s.running = false; s.elapsed = 0
+  arc.play{ {660,40}, {0,30}, {440,60} }
+end)
+
+arc.every(100, function(dt)
+  if s.running then s.elapsed = s.elapsed + dt end
+end)
+
+arc.view(function()
+  return ui.col{ pad = 8, gap = 6, align = "center",
+    ui.label{ text = arc.fmt_ms(s.elapsed), size = 4,
+              color = s.running and "green" or "white" },
+    ui.label{ text = s.running and "RUNNING" or "PAUSED",
+              size = 1, color = "gray" },
+    ui.label{ text = "A start/stop   B reset", size = 1, color = "dim" },
+  }
+end)
+```
+
+And the response loop, from the choose-your-own-adventure generation:
+
+```lua
+arc.on("choose", function(p)
+  buzzer.beep(660, 30)                      -- reflex: instant acknowledgment
+  local r = arc.ask("turn", { choice = p.choice }, {
+    timeout_ms = 9000,
+    fallback = { text = "The path is dark. Choose again.",
+                 a = s.a, b = s.b },
+  })
+  s.text, s.a, s.b = r.text, r.a or s.a, r.b or s.b
+end)
+
+arc.view(function()
+  return ui.col{ pad = 6, gap = 4,
+    ui.text{ text = s.text, size = 2, w = 228 },   -- word-wrapped
+    arc.pending("turn")
+      and ui.label{ text = "thinking" .. string.rep(".", arc.dots(3)),
+                    color = "amber" }
+      or  ui.col{ gap = 2,
+            ui.label{ text = "A: " .. s.a, size = 1, color = "cyan" },
+            ui.label{ text = "B: " .. s.b, size = 1, color = "cyan" } },
+  }
+end)
+```
+
+The full API surface is small enough to list (and small enough to sit in a
+system prompt, which is the point):
+
+```
+arc.store{defaults}                      one per app; returns the store
+arc.on(name, fn)                         intent handler (coroutine; gets payload)
+arc.tap(idx, name)                       button tap → intent
+arc.shake(g, name)                       accel magnitude → intent (1s refractory)
+arc.idle(ms, name)                       quiet spell → intent (once per spell)
+arc.intent(name, payload?)               inject an intent locally
+arc.ask(name, payload?, {timeout_ms, fallback})   suspend on the agent (handlers only)
+arc.pending(name?)                       ask in flight?
+arc.every(ms, fn) / arc.after(ms, fn)    timers → handle; arc.cancel(handle)
+arc.tween{from,to,ms,ease}               returns getter fn
+arc.play{{freq,ms},...}                  tone sequence (0 = rest)
+arc.view(fn)                             fn() → widget tree
+arc.publish(name, payload)               raw upstream event (rare)
+arc.fmt_ms(ms) / arc.dots(n)             tiny conveniences
+
+ui.col{pad,gap,align,...} ui.row{...}    layout (align: "start"|"center")
+ui.label{text,size,color}                one line
+ui.text{text,size,color,w}               word-wrapped block
+ui.rect{w,h,color,fill} ui.bar{value,w,h,color}
+ui.space{w,h} ui.qr{data,scale} ui.canvas{w,h,draw}
+colors: "white" "black" "gray" "dim" "red" "green" "blue" "amber" "cyan" "magenta" or {r,g,b}
+```
+
+Conventions that keep generations legible (enforced socially / by prompt,
+not by the runtime): one store, declared first; recognizers next; handlers
+next; timelines; view last. A generation should fit in ~60 lines. If it
+doesn't, the regime is probably two regimes.
+
+## 8. The agent loop
+
+Server-side (a `DeviceAgent` subclass in the existing server-template — 
+sketch, not shipped in this spike):
+
+```ts
+class ArcAgent extends DeviceAgent {
+  // durable state: deviceProfile (DEVICE-SKILL.md), generation source,
+  // mirror (latest arc:state), intent transcript (ring)
+  async onMessage(conn, msg) {
+    const e = parse(msg)
+    if (e.name === "arc:ask")    return this.answerAsk(e)      // response loop
+    if (e.name === "arc:state")  return this.mirror.update(e)
+    if (e.name === "arc:intent") {
+      this.transcript.push(e)
+      if (this.regimeChanged(e))  return this.regenerate()      // revision loop
+    }
+  }
+  async answerAsk(e) {
+    const reply = await claude({                                // claude-fable-5 /
+      system: ARC_CHEATSHEET + this.deviceProfile,              // claude-haiku for cheap asks
+      messages: context(this.generation, this.mirror, this.transcript, e),
+    })
+    this.send({ channel: "app", type: "arc:reply", data: { id: e.id, ...reply } })
+  }
+  async regenerate() {
+    const l3 = await claude({ /* profile + previous generation + mirror +
+      transcript + brief; asks for a NEW ~60-line arc generation */ })
+    this.send({ channel: "system", type: "app", code: ARC_LUA + gen(l3) })
+    this.send({ channel: "app", type: "arc:hydrate", data: carryOver(this.mirror) })
+  }
+}
+```
+
+Notes that matter more than the sketch:
+
+- **The previous generation is chain-of-thought.** When regenerating, the
+  agent reads its own last program — the policy is the plan, in a form that
+  diffs. This is why legibility conventions (§7) are load-bearing and not
+  aesthetics.
+- **Two model tiers.** Asks are latency-sensitive and narrow → small fast
+  model with a tight cheatsheet. Regenerations are rare and broad → big
+  model. The fallback covers both being slow.
+- **When to regenerate:** explicit user intent ("bored", a mode gesture),
+  schedule (`arc.idle` firing at night → ship the night generation),
+  ask-pressure (if every interaction escalates, the policy is at the wrong
+  altitude — push more behavior down), or external context changing.
+- **Fully generative, bootstrapped:** device connects → server has no
+  generation → ships a stock "hello" generation whose only behavior is
+  publishing intents and asking `"what should I be?"` — from there the
+  loop is closed and everything on the screen originated in inference,
+  cached as code.
+
+## 9. Honest limits & open problems
+
+Found by doing the design; kept here so the spike is a fair record.
+
+1. **Hydration is a round-trip.** State survives regeneration only via the
+   server. Device-side continuity (a store slot that survives `loadApp`,
+   deliberately exempt from `onAppReset`) would be better — candidate core
+   feature, with real design questions (when *should* it clear?).
+2. **Screen blanks on regeneration.** `loadApp` clears the sprite; a swap
+   visibly blinks. Mitigations: regenerate during natural blackouts, or a
+   core option to preserve the framebuffer until the first `flip`.
+3. **Recognizer poverty upstream.** The m5stick driver emits only
+   button-press events — no down/up, so no hold/long-press recognizers.
+   arc defines the raw vocabulary drivers *should* emit (down/up/repeat,
+   touch points, dial deltas); that's feedback into driver design.
+4. **10 FPS render quantum.** Fine for text/status UI; choppy for motion.
+   The shader path stays the high-FPS escape hatch; a core tick-rate config
+   is plausible.
+5. **256B flat payloads.** Right-sized for intents; tight for asks with
+   context and for the mirror of a bigger app. Chunking or a system-channel
+   sidecar would be needed past toy scale.
+6. **Event ring is 8 deep**, one delivery per loop — a fast tapper during a
+   pending ask could drop events. Acceptable at toy scale; worth a counter.
+7. **No partial code patching.** Whole-generation replacement is the only
+   behavior update. That's a considered position (§3.7), but component-level
+   regeneration (patch one handler) may earn its complexity once
+   generations grow. Requires `load()` in-sandbox or core support.
+8. **Multi-surface is designed, not built.** For the fan/face: the view
+   returns named surface trees (`{main=..., left=...}`) and continuous
+   actuators are bindings (§3.4). The toy targets the single m5stick screen.
+9. **`arc._gen` is a bake-in hack** — core should expose the generation id
+   to Lua (`ctx.generation_id`).
+10. **Runtime weight.** L1+L3 must fit compile-time and NVS persistence
+    budgets (`persist_too_big`). arc.lua stays under ~15KB; if it grows,
+    it moves into firmware as a preloaded module (which also fixes 2 and 7).
+
+Found live (examples/m5stick-arc, the deployed demo):
+
+11. **`events.send` doesn't escape JSON strings.** A quote in a value
+    corrupts the data payload, which then arrives as `{}`. arc sanitizes
+    (`"`→`'`, `\`→`/`) before publishing; the real fix is escaping in the
+    C++ serializer.
+12. **workers.dev TLS is Let's Encrypt**, not Cloudflare universal SSL, so
+    Courier's embedded GTS fallback root fails there when the build lacks
+    the IDF cert bundle (Arduino builds do). Devices pointed at workers.dev
+    must pin the ISRG roots.
+13. **A worker deploy resets the Durable Object** and drops the device's
+    WebSocket; sessions resume on reconnect but in-flight asks die (the
+    shipped fallback covers it — the design earning its keep).
+14. **Model-written views work.** claude-sonnet-5 reliably produces valid
+    arc view chunks under a ~2200-char budget with a luaparse syntax gate
+    and one retry-with-feedback; the renderer's pcall makes the residual
+    risk cosmetic rather than fatal.
+
+## 10. The toy, and how to run it
+
+```
+spikes/arc/
+  DESIGN.md          this file
+  arc.lua            L1 runtime (pure Lua, no host deps)
+  apps/stopwatch.lua reflex-only generation
+  apps/adventure.lua response-loop generation (ask/reply/fallback)
+  sim/sim.lua        host-side harness: stub drivers, tick clock, event injection
+  sim/scenarios.lua  scripted runs + assertions (the sim's test suite)
+```
+
+Run the scenarios (any Lua ≥5.1 on the host):
+
+```bash
+cd spikes/arc && lua sim/scenarios.lua
+```
+
+Push a generation to a real m5stick: concatenate runtime + generation and
+send it as a normal app —
+
+```bash
+cat arc.lua apps/stopwatch.lua > /tmp/out.lua
+# then push /tmp/out.lua with the usual resident:push-app flow
+```
+
+The sim stubs the m5stick surface from DEVICE-SKILL.md (`screen`, `imu`,
+`buzzer`, `button`, `events`, `log`), drives `on_tick` with a fake clock,
+injects `button`/`arc:*` events, and captures `events.send` — enough to
+exercise the full ask round-trip, timeout fallback, hydration, and the
+outbox's rate-limit retry without hardware.
+
+## 11. Roadmap sketch
+
+1. **Now (this spike):** concepts, L1 toy, two generations, sim.
+2. **Next:** ship arc.lua via a real server (`ArcAgent` on server-template),
+   wire a live m5stick, measure the seams (ask latency distribution, blink
+   on regen, rate-limit pressure).
+3. **Then:** device profiles for a second device (the fan — bindings,
+   no screen) to pressure-test the output taxonomy; store-survives-reload
+   in core; richer raw event vocabulary in drivers.
+4. **Later:** LVGL backend behind the same tree; component-level
+   regeneration; recognizers-as-models.

--- a/spikes/arc/apps/adventure.lua
+++ b/spikes/arc/apps/adventure.lua
@@ -1,0 +1,58 @@
+-- generation: adventure
+-- Choose-your-own-adventure. The next scene requires inference, so choosing
+-- escalates through arc.ask: the reflex loop acknowledges instantly (beep +
+-- "thinking" indicator), the agent replies with the new scene, and a timeout
+-- falls back to shipped microcopy. Shake asks the narrator to recap.
+
+local s = arc.store{
+  scene = 1,
+  text  = "You wake in a moonlit orchard. A lantern glows by the gate, and something rustles in the long grass.",
+  a     = "Take the lantern",
+  b     = "Follow the rustle",
+}
+
+arc.tap(0, "choose_a")
+arc.tap(1, "choose_b")
+arc.shake(2.0, "recap")
+arc.idle(120000, "bored")
+
+local function turn(choice)
+  buzzer.beep(660, 30)                       -- reflex acknowledgment
+  local r = arc.ask("turn", { choice = choice, scene = s.scene }, {
+    timeout_ms = 9000,
+    fallback = { text = "The mist thickens and the moment passes. The orchard waits for you to choose again." },
+  })
+  if r.text then s.text = r.text end
+  if r.a then s.a = r.a end
+  if r.b then s.b = r.b end
+  if r.scene then s.scene = r.scene end
+  arc.play{ {520, 40}, {0, 20}, {780, 60} }  -- page-turn chime on arrival
+end
+
+arc.on("choose_a", function() turn("a") end)
+arc.on("choose_b", function() turn("b") end)
+
+arc.on("recap", function()
+  local r = arc.ask("recap", { scene = s.scene }, {
+    timeout_ms = 6000,
+    fallback = { text = "The story so far is lost in the wind." },
+  })
+  if r.text then s.text = r.text end
+end)
+
+-- "bored" has no local handler: it is published upstream, where the agent
+-- may decide to regenerate this app into something else entirely.
+
+arc.view(function()
+  local busy = arc.pending()
+  return ui.col{ pad = 6, gap = 5,
+    ui.text{ text = s.text, size = 2, w = 228, color = "white" },
+    busy
+      and ui.label{ text = "thinking" .. string.rep(".", arc.dots(3)),
+                    size = 2, color = "amber" }
+      or ui.col{ gap = 2,
+           ui.label{ text = "A: " .. s.a, size = 1, color = "cyan" },
+           ui.label{ text = "B: " .. s.b, size = 1, color = "cyan" },
+         },
+  }
+end)

--- a/spikes/arc/apps/stopwatch.lua
+++ b/spikes/arc/apps/stopwatch.lua
@@ -1,0 +1,34 @@
+-- generation: stopwatch
+-- Pure reflex loop — after shipping, this needs zero agent involvement.
+-- Button A (0) start/stop, button B (1) reset.
+
+local s = arc.store{ running = false, elapsed = 0, laps = 0 }
+
+arc.tap(0, "toggle")
+arc.tap(1, "reset")
+
+arc.on("toggle", function()
+  s.running = not s.running
+  buzzer.beep(s.running and 880 or 440, 40)
+end)
+
+arc.on("reset", function()
+  s.running = false
+  s.elapsed = 0
+  arc.play{ {660, 40}, {0, 30}, {440, 60} }
+end)
+
+arc.every(100, function(dt)
+  if s.running then s.elapsed = s.elapsed + dt end
+end)
+
+arc.view(function()
+  return ui.col{ pad = 10, gap = 8, align = "center",
+    ui.space{ h = 4 },
+    ui.label{ text = arc.fmt_ms(s.elapsed), size = 4,
+              color = s.running and "green" or "white" },
+    ui.label{ text = s.running and "RUNNING" or "PAUSED",
+              size = 2, color = s.running and "green" or "gray" },
+    ui.label{ text = "A start/stop    B reset", size = 1, color = "dim" },
+  }
+end)

--- a/spikes/arc/arc.lua
+++ b/spikes/arc/arc.lua
@@ -1,0 +1,530 @@
+-- arc — L1 runtime for generative device UI on the Resident sandbox.
+-- Spike / toy implementation. See DESIGN.md.
+--
+-- This file is concatenated ahead of a generation (the agent- or
+-- human-written app) and pushed as one Resident app. It defines the
+-- sandbox lifecycle globals (init / on_tick / on_event) itself;
+-- generations only call arc.* / ui.* and never define those.
+--
+-- Written against Lua 5.1+ (device interpreter and host sim both work).
+
+arc = arc or {}   -- the server may prepend `arc = { _gen = "<id>" }`
+ui  = {}
+
+arc._gen = arc._gen or "dev"
+
+-- ---------------------------------------------------------------------------
+-- internals
+
+local now = 0                  -- ctx.time_ms, refreshed on every callback
+local dirty = true             -- view needs re-render
+local store_raw = nil          -- backing table of the store proxy
+local store_dirty = false      -- mirror needs (throttled) publish
+local view_fn = nil
+local handlers = {}            -- intent name -> fn
+local running = {}             -- coroutine -> true while it is a live handler
+local timers = {}              -- list of {at, every, fn, last, dead}
+local taps = {}                -- button index -> intent name
+local shakes = {}              -- list of {g, name, until_ms}
+local idles = {}               -- list of {ms, name, fired}
+local last_activity = 0
+local pending = {}             -- ask id -> {co, name, deadline, fallback}
+local next_ask_id = 1
+local outbox = {}              -- list of {name, data, keep}
+local OUTBOX_MAX = 16
+local STATE_MIN_INTERVAL = 5000
+local last_state_sent = -STATE_MIN_INTERVAL
+
+local unpack_ = table.unpack or unpack
+
+local function flatten(t)
+  -- events.send accepts flat string/number values only; booleans -> 1/0.
+  -- Its serializer does NOT escape JSON specials, so a quote or backslash in
+  -- a value corrupts the payload (it arrives as {}) — sanitize them away.
+  local out = {}
+  if t then
+    for k, v in pairs(t) do
+      local tv = type(v)
+      if tv == "string" then out[k] = v:gsub('"', "'"):gsub("\\", "/")
+      elseif tv == "number" then out[k] = v
+      elseif tv == "boolean" then out[k] = v and 1 or 0 end
+    end
+  end
+  return out
+end
+
+local function merged(base, extra)
+  local out = flatten(extra)
+  for k, v in pairs(base) do out[k] = v end   -- reserved keys win
+  return out
+end
+
+local function outbox_push(name, data, keep)
+  if #outbox >= OUTBOX_MAX then
+    for i, m in ipairs(outbox) do            -- drop oldest droppable, never asks
+      if not m.keep then table.remove(outbox, i); break end
+    end
+    if #outbox >= OUTBOX_MAX then return end -- all keepers: drop this one
+  end
+  outbox[#outbox + 1] = { name = name, data = data, keep = keep }
+end
+
+local function outbox_drain()
+  while outbox[1] do
+    if events.send(outbox[1].name, outbox[1].data) then
+      table.remove(outbox, 1)
+    else
+      return  -- rate-limited or offline; retry next tick
+    end
+  end
+end
+
+local function resume(co, ...)
+  local ok, err = coroutine.resume(co, ...)
+  if not ok then log.error("arc handler: " .. tostring(err)) end
+  if coroutine.status(co) == "dead" then running[co] = nil end
+  dirty = true
+end
+
+-- ---------------------------------------------------------------------------
+-- store
+
+function arc.store(defaults)
+  if store_raw then error("arc.store: only one store per app", 2) end
+  store_raw = {}
+  for k, v in pairs(defaults or {}) do store_raw[k] = v end
+  arc._raw_store = store_raw   -- debug/sim access
+  return setmetatable({}, {
+    __index = store_raw,
+    __newindex = function(_, k, v)
+      if store_raw[k] ~= v then
+        store_raw[k] = v
+        dirty = true
+        store_dirty = true
+      end
+    end,
+  })
+end
+
+-- ---------------------------------------------------------------------------
+-- intent bus
+
+function arc.on(name, fn) handlers[name] = fn end
+
+local function dispatch(name, payload, is_activity)
+  if is_activity then
+    last_activity = now
+    for _, w in ipairs(idles) do w.fired = false end
+  end
+  outbox_push("arc:intent", merged({ name = name }, payload))
+  local fn = handlers[name]
+  if fn then
+    local co = coroutine.create(fn)
+    running[co] = true
+    resume(co, payload or {})
+  end
+  dirty = true
+end
+
+function arc.intent(name, payload) dispatch(name, payload, true) end
+
+-- recognizers -----------------------------------------------------------------
+
+function arc.tap(index, name) taps[index] = name end
+
+function arc.shake(g, name)
+  shakes[#shakes + 1] = { g = g, name = name, until_ms = 0 }
+end
+
+function arc.idle(ms, name)
+  idles[#idles + 1] = { ms = ms, name = name, fired = false }
+end
+
+-- asks ------------------------------------------------------------------------
+
+function arc.ask(name, payload, opts)
+  opts = opts or {}
+  local co = coroutine.running()
+  if not co or not running[co] then
+    error("arc.ask must be called inside an intent handler", 2)
+  end
+  local id = next_ask_id
+  next_ask_id = next_ask_id + 1
+  pending[id] = {
+    co = co, name = name,
+    deadline = now + (opts.timeout_ms or 10000),
+    fallback = opts.fallback,
+    payload = payload,
+  }
+  outbox_push("arc:ask",
+    merged({ ask = name, id = id, gen = arc._gen }, payload), true)
+  dirty = true                       -- render the pending state immediately
+  return coroutine.yield()
+end
+
+-- Returns the pending ask's PAYLOAD (truthy table) rather than a bare true,
+-- so the view can echo what was asked during the wait — e.g. highlight the
+-- choice the user just made. Falsy when nothing is pending.
+function arc.pending(name)
+  for _, p in pairs(pending) do
+    if name == nil or p.name == name then return p.payload or true end
+  end
+  return false
+end
+
+-- timelines -------------------------------------------------------------------
+
+function arc.every(ms, fn)
+  local t = { at = now + ms, every = ms, fn = fn, last = now }
+  timers[#timers + 1] = t
+  return t
+end
+
+function arc.after(ms, fn)
+  local t = { at = now + ms, fn = fn, last = now }
+  timers[#timers + 1] = t
+  return t
+end
+
+function arc.cancel(t) if t then t.dead = true end end
+
+function arc.tween(o)
+  local from, to, ms = o.from or 0, o.to or 1, o.ms or 300
+  local ease, t0 = o.ease or "linear", now
+  return function()
+    local p = ms > 0 and (now - t0) / ms or 1
+    if p < 0 then p = 0 elseif p > 1 then p = 1 end
+    if ease == "in" then p = p * p
+    elseif ease == "out" then p = 1 - (1 - p) * (1 - p) end
+    return from + (to - from) * p
+  end
+end
+
+function arc.play(notes)
+  local at = 0
+  for _, n in ipairs(notes) do
+    local freq, ms = n[1], n[2]
+    if freq > 0 then
+      if at == 0 then buzzer.beep(freq, ms)
+      else arc.after(at, function() buzzer.beep(freq, ms) end) end
+    end
+    at = at + ms
+  end
+end
+
+-- misc ------------------------------------------------------------------------
+
+function arc.publish(name, payload) outbox_push(name, flatten(payload)) end
+
+function arc.view(fn) view_fn = fn end
+
+function arc.fmt_ms(ms)
+  local m = math.floor(ms / 60000)
+  local s = math.floor(ms / 1000) % 60
+  local t = math.floor(ms / 100) % 10
+  return string.format("%02d:%02d.%d", m, s, t)
+end
+
+function arc.dots(n) return 1 + math.floor(now / 400) % n end
+
+-- ---------------------------------------------------------------------------
+-- ui: widgets are plain tables; the renderer below is deliberately dumb
+
+local PALETTE = {
+  white = {255,255,255}, black = {0,0,0},     gray = {160,160,160},
+  dim   = {90,90,90},    red   = {255,80,80}, green = {80,255,120},
+  blue  = {80,160,255},  amber = {255,190,60}, cyan = {80,220,255},
+  magenta = {255,80,255},
+}
+
+local function rgbc(c)
+  if type(c) == "string" then c = PALETTE[c] end
+  c = c or PALETTE.white
+  return c[1], c[2], c[3]
+end
+
+local function widget(kind)
+  return function(t) t.kind = kind; return t end
+end
+
+ui.col    = widget("col")
+ui.row    = widget("row")
+ui.label  = widget("label")
+ui.text   = widget("text")
+ui.rect   = widget("rect")
+ui.bar    = widget("bar")
+ui.space  = widget("space")
+ui.qr     = widget("qr")
+ui.canvas = widget("canvas")
+
+local CHAR_W, CHAR_H = 6, 8    -- base font cell; multiplied by size
+
+local function wrap_text(str, size, w)
+  local maxc = math.max(1, math.floor(w / (CHAR_W * size)))
+  local lines, line = {}, ""
+  for w in tostring(str):gmatch("%S+") do
+    local word = w
+    while #word > maxc do                      -- hard-split oversized words
+      if #line > 0 then lines[#lines + 1] = line; line = "" end
+      lines[#lines + 1] = word:sub(1, maxc)
+      word = word:sub(maxc + 1)
+    end
+    if line == "" then line = word
+    elseif #line + 1 + #word <= maxc then line = line .. " " .. word
+    else lines[#lines + 1] = line; line = word end
+  end
+  if #line > 0 then lines[#lines + 1] = line end
+  if #lines == 0 then lines[1] = "" end
+  return lines
+end
+
+local measure
+
+local function measure_children(w)
+  local ws, hs, kids = {}, {}, {}
+  for _, child in ipairs(w) do
+    if type(child) == "table" then             -- skip false/holes from conds
+      local cw, ch = measure(child)
+      kids[#kids + 1] = child
+      ws[#ws + 1] = cw
+      hs[#hs + 1] = ch
+    end
+  end
+  return kids, ws, hs
+end
+
+measure = function(w)
+  local k = w.kind
+  if k == "label" then
+    local size = w.size or 2
+    return #tostring(w.text or "") * CHAR_W * size, CHAR_H * size
+  elseif k == "text" then
+    local size = w.size or 2
+    w._lines = wrap_text(w.text or "", size, w.w or 228)
+    local widest = 0
+    for _, l in ipairs(w._lines) do widest = math.max(widest, #l) end
+    return widest * CHAR_W * size, #w._lines * CHAR_H * size
+  elseif k == "rect" or k == "canvas" or k == "space" or k == "bar" then
+    return w.w or 0, w.h or 0
+  elseif k == "qr" then
+    return 33 * (w.scale or 4), 33 * (w.scale or 4)
+  elseif k == "col" or k == "row" then
+    local pad, gap = w.pad or 0, w.gap or 0
+    local kids, ws, hs = measure_children(w)
+    w._kids, w._ws, w._hs = kids, ws, hs
+    local main, cross = 0, 0
+    for i = 1, #kids do
+      if k == "col" then
+        main = main + hs[i]; cross = math.max(cross, ws[i])
+      else
+        main = main + ws[i]; cross = math.max(cross, hs[i])
+      end
+    end
+    if #kids > 0 then main = main + gap * (#kids - 1) end
+    if k == "col" then return cross + 2 * pad, main + 2 * pad
+    else return main + 2 * pad, cross + 2 * pad end
+  end
+  return 0, 0
+end
+
+local draw
+
+local function draw_stack(w, x, y)
+  local pad, gap = w.pad or 0, w.gap or 0
+  local ww, wh = measure(w)  -- refresh _kids/_ws/_hs (cheap, tree is tiny)
+  local cx, cy = x + pad, y + pad
+  for i, child in ipairs(w._kids) do
+    local dx, dy = cx, cy
+    if w.align == "center" then
+      if w.kind == "col" then dx = x + math.floor((ww - w._ws[i]) / 2)
+      else dy = y + math.floor((wh - w._hs[i]) / 2) end
+    end
+    draw(child, dx, dy)
+    if w.kind == "col" then cy = cy + w._hs[i] + gap
+    else cx = cx + w._ws[i] + gap end
+  end
+end
+
+draw = function(w, x, y)
+  x, y = math.floor(x), math.floor(y)
+  local k = w.kind
+  if k == "label" then
+    local r, g, b = rgbc(w.color)
+    screen.text(x, y, tostring(w.text or ""), w.size or 2, r, g, b)
+  elseif k == "text" then
+    local size = w.size or 2
+    local r, g, b = rgbc(w.color)
+    for i, line in ipairs(w._lines or wrap_text(w.text or "", size, w.w or 228)) do
+      screen.text(x, y + (i - 1) * CHAR_H * size, line, size, r, g, b)
+    end
+  elseif k == "rect" then
+    local r, g, b = rgbc(w.color)
+    if w.fill == false then screen.rect(x, y, w.w, w.h, r, g, b)
+    else screen.fill_rect(x, y, w.w, w.h, r, g, b) end
+  elseif k == "bar" then
+    local r, g, b = rgbc(w.color)
+    local v = math.max(0, math.min(1, w.value or 0))
+    screen.rect(x, y, w.w, w.h, r, g, b)
+    local fw = math.floor((w.w - 4) * v)
+    if fw > 0 then screen.fill_rect(x + 2, y + 2, fw, w.h - 4, r, g, b) end
+  elseif k == "qr" then
+    screen.qr(x, y, tostring(w.data or ""), w.scale or 4)
+  elseif k == "canvas" then
+    if w.draw then w.draw(x, y) end
+  elseif k == "col" or k == "row" then
+    draw_stack(w, x, y)
+  end
+end
+
+local activity_on = true
+function arc.activity(on) activity_on = (on ~= false) end
+
+-- System chrome: whenever an ask is in flight, the runtime itself draws a
+-- small pulsing indicator (three amber dots, bottom-right). Views can add
+-- richer treatments on top, but silently running inference is not the
+-- default — an app must opt out (arc.activity(false)) to hide it.
+local function draw_activity()
+  if not activity_on or next(pending) == nil then return end
+  local w, h = screen.width(), screen.height()
+  local lit = 1 + math.floor(now / 300) % 3
+  for i = 1, 3 do
+    local x = w - 24 + (i - 1) * 7
+    if i == lit then screen.fill_rect(x, h - 7, 4, 4, 255, 190, 60)
+    else screen.fill_rect(x, h - 6, 4, 2, 90, 70, 25) end
+  end
+end
+
+local function render()
+  if not view_fn then return end
+  -- the whole pipeline is protected: a bad view (e.g. a model-written one)
+  -- must never take the app down — it logs and leaves the last frame up
+  local ok, err = pcall(function()
+    local tree = view_fn()
+    arc._last_tree = tree      -- debug/sim access; also the mirror's view
+    screen.clear()
+    draw(tree, 0, 0)
+    draw_activity()
+    screen.flip()
+  end)
+  if not ok then log.error("arc view: " .. tostring(err)); return end
+  dirty = false
+end
+
+-- ---------------------------------------------------------------------------
+-- mirror
+
+local function send_state(force)
+  if not store_raw then return end
+  if not force and now - last_state_sent < STATE_MIN_INTERVAL then return end
+  -- events.send serializes into a bounded 256-byte buffer; trim long strings
+  -- so the mirror arrives intact rather than truncated mid-JSON
+  local snap = merged({ gen = arc._gen }, store_raw)
+  for k, v in pairs(snap) do
+    if type(v) == "string" and #v > 40 then snap[k] = v:sub(1, 37) .. "..." end
+  end
+  outbox_push("arc:state", snap)
+  last_state_sent = now
+  store_dirty = false
+end
+
+-- ---------------------------------------------------------------------------
+-- sandbox lifecycle (the only place these globals are defined)
+
+function init(ctx)
+  now = ctx.time_ms or 0
+  last_activity = now
+  send_state(true)
+  outbox_drain()
+  render()
+end
+
+function on_tick(ctx, dt_ms)
+  now = ctx.time_ms
+
+  -- timers (guard against timers added during iteration: snapshot length)
+  local n = #timers
+  for i = 1, n do
+    local t = timers[i]
+    if not t.dead and now >= t.at then
+      if t.every then
+        t.at = now + t.every
+        local dt = now - t.last
+        t.last = now
+        t.fn(dt)
+      else
+        t.dead = true
+        t.fn()
+      end
+    end
+  end
+  for i = #timers, 1, -1 do
+    if timers[i].dead then table.remove(timers, i) end
+  end
+
+  -- shake recognizer
+  if #shakes > 0 then
+    local ax, ay, az = imu.accel()
+    local mag = math.sqrt(ax * ax + ay * ay + az * az)
+    for _, sh in ipairs(shakes) do
+      if mag > sh.g and now >= sh.until_ms then
+        sh.until_ms = now + 1000
+        dispatch(sh.name, { mag = math.floor(mag * 100) / 100 }, true)
+      end
+    end
+  end
+
+  -- idle recognizer (an idle intent is not user activity: no resets)
+  for _, w in ipairs(idles) do
+    if not w.fired and now - last_activity >= w.ms then
+      w.fired = true
+      dispatch(w.name, { quiet_ms = now - last_activity }, false)
+    end
+  end
+
+  -- ask timeouts
+  for id, p in pairs(pending) do
+    if now >= p.deadline then
+      pending[id] = nil
+      log.warn("arc ask '" .. p.name .. "' timed out; using fallback")
+      resume(p.co, p.fallback or {})
+    end
+  end
+
+  if store_dirty then send_state(false) end
+  outbox_drain()
+
+  render()
+end
+
+function on_event(ctx, e)
+  -- note: e.ts_ms is millis-since-boot, a different epoch from ctx.time_ms;
+  -- `now` stays at the last tick's value (≤100ms stale, fine for a reflex)
+  if e.name == "arc:reply" then
+    local d = e.data or {}
+    local p = d.id and pending[d.id]
+    if p then
+      pending[d.id] = nil
+      resume(p.co, d)
+    else
+      log.warn("arc: reply for unknown ask id " .. tostring(d.id))
+    end
+  elseif e.name == "arc:hydrate" then
+    if store_raw then
+      for k, v in pairs(e.data or {}) do
+        store_raw[k] = v
+      end
+      dirty = true; store_dirty = true
+    end
+  elseif e.name == "arc:probe" then
+    send_state(true)
+  elseif e.name == "button" then
+    local name = taps[e.index]
+    if name then arc.intent(name, { index = e.index }) end
+  else
+    arc.intent(e.name, e.data)
+  end
+  if dirty then render() end   -- input→pixel inside the 150ms budget
+  outbox_drain()               -- asks shouldn't wait for the next tick
+end
+
+-- end of arc runtime --------------------------------------------------------

--- a/spikes/arc/sim/scenarios.lua
+++ b/spikes/arc/sim/scenarios.lua
@@ -1,0 +1,142 @@
+-- scenarios — scripted runs of the example generations, with assertions.
+-- Run from spikes/arc/:  lua sim/scenarios.lua
+
+local sim = dofile("sim/sim.lua")
+
+local passed, failed = 0, 0
+
+local function check(cond, what)
+  if cond then
+    passed = passed + 1
+  else
+    failed = failed + 1
+    print("  FAIL: " .. what)
+  end
+end
+
+local function has(haystack, needle)
+  return tostring(haystack):find(needle, 1, true) ~= nil
+end
+
+-- ---------------------------------------------------------------------------
+print("scenario: stopwatch (reflex loop only)")
+sim.load("apps/stopwatch.lua")
+
+check(has(sim.texts(), "00:00.0"), "shows zero time at boot")
+check(has(sim.texts(), "PAUSED"), "starts paused")
+check(sim.offscreen() == nil, "stopwatch frame in bounds (" .. tostring(sim.offscreen()) .. ")")
+check(sim.last_sent("arc:state") ~= nil, "hello mirror published on init")
+
+sim.button(0)                                 -- start
+check(arc._raw_store.running == true, "tap A starts the clock")
+check(sim.beeped(880), "start beep is reflex (fires before any tick)")
+check(has(sim.texts(), "RUNNING"), "render happens on the event, not the next tick")
+local i = sim.last_sent("arc:intent")
+check(i and i.name == "toggle" and i.index == 0, "intent published upstream with payload")
+
+sim.tick(10)                                  -- 1.0s
+check(arc._raw_store.elapsed == 1000, "timer accumulates elapsed (got " .. tostring(arc._raw_store.elapsed) .. ")")
+check(has(sim.texts(), "00:01.0"), "time renders")
+
+sim.button(0)                                 -- pause
+sim.tick(5)
+check(arc._raw_store.elapsed == 1000, "paused clock does not accumulate")
+
+sim.button(1)                                 -- reset
+check(arc._raw_store.elapsed == 0, "reset zeroes the clock")
+check(sim.beeped(660), "reset chime first note is immediate")
+sim.tick(1)
+check(sim.beeped(440), "reset chime second note plays from the timeline")
+
+-- ---------------------------------------------------------------------------
+print("scenario: adventure (response loop: ask / reply)")
+sim.load("apps/adventure.lua")
+
+check(has(sim.texts(), "moonlit orchard"), "opening scene shows")
+check(has(sim.texts(), "A: Take the lantern"), "choices show")
+check(sim.offscreen() == nil, "adventure frame in bounds (" .. tostring(sim.offscreen()) .. ")")
+
+sim.button(0)                                 -- choose A -> escalates
+check(sim.beeped(660), "acknowledgment beep is reflex")
+local ask = sim.last_sent("arc:ask")
+check(ask ~= nil, "ask published immediately (no tick needed)")
+check(ask and ask.ask == "turn" and ask.choice == "a" and ask.gen == "dev",
+      "ask carries name, payload, generation id")
+check(arc.pending("turn"), "ask is pending")
+local pp = arc.pending("turn")
+check(type(pp) == "table" and pp.choice == "a", "pending returns the ask payload for local echo")
+check(has(sim.texts(), "thinking"), "fallback UI within the reflex budget")
+local dots = false
+for _, op in ipairs(sim.drawops) do
+  if op.op == "fill_rect" and op.x >= 216 and op.y >= 128 then dots = true end
+end
+check(dots, "runtime draws system activity dots while an ask is pending")
+check(not has(sim.texts(), "A: Take the lantern"), "choices hidden while pending")
+
+sim.tick(3)
+sim.appevent("arc:reply", { id = ask.id, text = "The lantern hums as you lift it. The gate swings open onto a starlit road.",
+                            a = "Walk the road", b = "Snuff the lantern", scene = 2 })
+check(not arc.pending(), "reply resolves the ask")
+check(has(sim.texts(), "lantern hums"), "scene advances from the reply")
+check(has(sim.texts(), "A: Walk the road"), "choices update from the reply")
+check(arc._raw_store.scene == 2, "store carries the reply's state")
+check(sim.beeped(520), "arrival chime")
+
+-- timeout -> fallback
+sim.button(1)                                 -- choose B, agent never replies
+check(arc.pending("turn"), "second ask pending")
+sim.tick(95)                                  -- 9.5s > 9s timeout
+check(not arc.pending(), "timeout clears the ask")
+check(has(sim.texts(), "mist thickens"), "shipped fallback text shows")
+check(has(sim.texts(), "A: Walk the road"), "fallback preserves prior choices")
+
+-- hydration + probe (revision-loop plumbing)
+sim.appevent("arc:hydrate", { text = "Hydrated scene text." })
+check(has(sim.texts(), "Hydrated scene text."), "hydrate merges into the store and re-renders")
+
+local states_before = sim.sent_count("arc:state")
+sim.appevent("arc:probe", {})
+sim.tick(1)
+check(sim.sent_count("arc:state") > states_before, "probe publishes the mirror")
+local st = sim.last_sent("arc:state")
+check(st and st.scene == 2 and st.gen == "dev", "mirror carries store + generation id")
+
+-- unknown reply id is ignored, not fatal
+sim.appevent("arc:reply", { id = 999, text = "stale" })
+check(not has(sim.texts(), "stale"), "stale/unknown reply dropped")
+
+-- server-sent event with no arc: prefix becomes an intent
+sim.appevent("recap", {})                     -- agent injects an intent
+check(arc.pending("recap"), "agent-injected event runs the same handler as a shake")
+sim.appevent("arc:reply", { id = (sim.last_sent("arc:ask") or {}).id,
+                            text = "So far: you took the lantern." })
+check(has(sim.texts(), "So far"), "recap reply lands")
+
+-- rate limiting: outbox holds and retries
+local asks_before = sim.sent_count("arc:ask")
+sim.send_ok = false
+sim.button(0)
+check(sim.sent_count("arc:ask") == asks_before, "rate-limited ask is queued, not sent")
+check(arc.pending("turn"), "ask pending even while unsendable")
+check(has(sim.texts(), "thinking"), "UI doesn't wait for the network")
+sim.send_ok = true
+sim.tick(1)
+check(sim.sent_count("arc:ask") == asks_before + 1, "outbox retries the ask once the limiter clears")
+sim.appevent("arc:reply", { id = (sim.last_sent("arc:ask") or {}).id, text = "Onward." })
+
+-- idle recognizer fires once, upstream only
+sim.tick(1250)                                -- > 120s quiet
+local found_bored = false
+for _, m in ipairs(sim.sent) do
+  if m.name == "arc:intent" and m.data.name == "bored" then found_bored = true end
+end
+check(found_bored, "idle publishes 'bored' for the agent's revision loop")
+
+-- shake recognizer
+sim.accel = { 2.5, 0, 1 }
+sim.tick(1)
+check(arc.pending("recap"), "shake magnitude triggers the recap ask")
+
+-- ---------------------------------------------------------------------------
+print(string.format("\n%d passed, %d failed", passed, failed))
+if failed > 0 then os.exit(1) end

--- a/spikes/arc/sim/sim.lua
+++ b/spikes/arc/sim/sim.lua
@@ -1,0 +1,158 @@
+-- sim — host-side harness for arc generations.
+-- Stubs the m5stick sandbox surface (per examples/m5stick-demo/DEVICE-SKILL.md),
+-- drives the tick clock, injects events, captures upstream sends.
+-- Run from spikes/arc/:  lua sim/scenarios.lua
+
+local sim = {}
+
+sim.time    = 0
+sim.sent    = {}     -- captured events.send calls: {name=, data=}
+sim.beeps   = {}     -- captured buzzer.beep calls: {freq, ms}
+sim.logs    = {}     -- captured log lines: {level, msg}
+sim.accel   = { 0, 0, 1 }
+sim.send_ok = true   -- set false to simulate the rate limiter / offline
+sim.flips   = 0
+sim.drawops = {}     -- draw calls in the current frame (screen.clear resets)
+
+local function copy(t)
+  local out = {}
+  for k, v in pairs(t or {}) do out[k] = v end
+  return out
+end
+
+local function install_stubs()
+  local function noop() end
+
+  screen = setmetatable({
+    width  = function() return 240 end,
+    height = function() return 135 end,
+    flip   = function() sim.flips = sim.flips + 1 end,
+    clear  = function() sim.drawops = {} end,
+    text   = function(x, y, str, size, r, g, b)
+      sim.drawops[#sim.drawops + 1] =
+        { op = "text", x = x, y = y, str = str, size = size or 2 }
+    end,
+    fill_rect = function(x, y, w, h)
+      sim.drawops[#sim.drawops + 1] =
+        { op = "fill_rect", x = x, y = y, w = w, h = h }
+    end,
+    rect = function(x, y, w, h)
+      sim.drawops[#sim.drawops + 1] =
+        { op = "rect", x = x, y = y, w = w, h = h }
+    end,
+  }, { __index = function() return noop end })
+
+  imu = {
+    accel = function() return sim.accel[1], sim.accel[2], sim.accel[3] end,
+    gyro  = function() return 0, 0, 0 end,
+    temp  = function() return 0 end,
+  }
+
+  buzzer = setmetatable({
+    beep = function(freq, ms) sim.beeps[#sim.beeps + 1] = { freq, ms } end,
+  }, { __index = function() return noop end })
+
+  button = { press_count = function() return 0 end }
+
+  events = {
+    send = function(name, data)
+      if not sim.send_ok then return false end
+      sim.sent[#sim.sent + 1] = { name = name, data = copy(data) }
+      return true
+    end,
+  }
+
+  log = {
+    info  = function(m) sim.logs[#sim.logs + 1] = { "info", m } end,
+    warn  = function(m) sim.logs[#sim.logs + 1] = { "warn", m } end,
+    error = function(m) sim.logs[#sim.logs + 1] = { "error", m } end,
+  }
+end
+
+local function ctx()
+  return { time_ms = sim.time, trigger_count = 0,
+           utc_h = 12, utc_m = 0, localtime_h = 12, localtime_m = 0 }
+end
+
+function sim.load(app_path)
+  sim.time, sim.sent, sim.beeps, sim.logs = 0, {}, {}, {}
+  sim.accel, sim.send_ok, sim.flips = { 0, 0, 1 }, true, 0
+  sim.drawops = {}
+  install_stubs()
+  arc = nil                       -- fresh runtime state on re-dofile
+  dofile("arc.lua")
+  dofile(app_path)
+  init(ctx())
+end
+
+function sim.tick(n)
+  for _ = 1, (n or 1) do
+    sim.time = sim.time + 100
+    on_tick(ctx(), 100)
+  end
+end
+
+function sim.button(index)
+  on_event(ctx(), { name = "button", index = index, from = "", ts_ms = sim.time })
+end
+
+function sim.appevent(type_, data)
+  on_event(ctx(), { name = type_, data = data or {}, from = "server", ts_ms = sim.time })
+end
+
+-- assertions helpers ---------------------------------------------------------
+
+function sim.texts()
+  local out = {}
+  local function walk(w)
+    if type(w) ~= "table" then return end
+    if w.kind == "label" or w.kind == "text" then
+      out[#out + 1] = tostring(w.text or "")
+    end
+    for _, child in ipairs(w) do walk(child) end
+  end
+  walk(arc._last_tree)
+  return table.concat(out, " | ")
+end
+
+function sim.last_sent(name)
+  for i = #sim.sent, 1, -1 do
+    if sim.sent[i].name == name then return sim.sent[i].data end
+  end
+  return nil
+end
+
+function sim.sent_count(name)
+  local n = 0
+  for _, m in ipairs(sim.sent) do
+    if m.name == name then n = n + 1 end
+  end
+  return n
+end
+
+-- Returns nil if every draw op in the current frame is inside the screen
+-- (and every text line fits its own width), else a description of the first
+-- offender. The strictest cheap check we have on the layout engine.
+function sim.offscreen()
+  for _, d in ipairs(sim.drawops) do
+    local w, h
+    if d.op == "text" then
+      w, h = #d.str * 6 * d.size, 8 * d.size
+    else
+      w, h = d.w, d.h
+    end
+    if d.x < 0 or d.y < 0 or d.x + w > 240 or d.y + h > 135 then
+      return string.format("%s at (%d,%d) size %dx%d", d.op, d.x, d.y, w, h)
+    end
+  end
+  return nil
+end
+
+function sim.beeped(freq)
+  for _, b in ipairs(sim.beeps) do
+    if b[1] == freq then return true end
+  end
+  return false
+end
+
+return sim

--- a/tools/run-tests.py
+++ b/tools/run-tests.py
@@ -82,6 +82,8 @@ PLATFORMIO_EXAMPLES: list[Path | tuple[Path, str]] = [
     ROOT / "examples" / "adafruit-esp32-s2-feather" / "device-no-resident",
     (ROOT / "examples" / "m5stick-voice" / "device", "m5stick"),
     (ROOT / "examples" / "m5stick-voice" / "device", "m5sticks3"),
+    (ROOT / "examples" / "m5stick-arc" / "device", "m5stick"),
+    (ROOT / "examples" / "m5stick-arc" / "device", "m5sticks3"),
 ]
 
 


### PR DESCRIPTION
## Summary

Spike into a reactive framework (**arc**) for fully generative device UI on the Resident sandbox, plus a live demo example.

**`spikes/arc/`** — design + toy:
- `DESIGN.md`: first-principles concepts. A program is cached inference; the agent ships behavior forward in time. Three loops: **reflex** (<150ms, on device), **response** (asks: Suspense-for-inference with mandatory fallbacks), **revision** (whole-program regeneration with state hydration). Elm-shaped core (one store, intent bus, view-as-data) so the device is legible to the model as a few tokens (the mirror). Alternatives considered and rejected (Rx-first, mini-React, SDUI, new DSL, LVGL) with reasons.
- `arc.lua`: ~500-line pure-Lua runtime — intent bus, recognizers (tap/shake/idle), coroutine `arc.ask` with timeout+fallback, timelines, widget renderer, outbox honoring the 5/s / 256B data plane, runtime-drawn activity chrome (silent inference requires explicit opt-out), pending-ask payloads for local choice echo.
- `sim/`: host-side harness (46 assertions) — full ask/reply/timeout/hydrate cycle, layout bounds checking, no hardware needed.

**`examples/m5stick-arc/`** — the loop, live:
- Choose-your-own-adventure: story turns by claude-haiku-4-5 (~1s), and **shake = remix**: claude-sonnet-5 writes a brand-new Lua view function at runtime — vetted with luaparse, spliced into the generation, pushed with story state baked in. Tilt = pure-reflex lantern glow whose value rides in each ask.
- Worker: `ArcAgent extends DeviceAgent`, inference via AI Gateway BYOK (no model secrets in the worker), live viewer page on the monitor WebSocket.
- Firmware: m5stick-demo drivers + `le_roots.h` (workers.dev serves Let's Encrypt; Arduino builds lack the IDF cert bundle, and Courier's embedded fallback is GTS-only).

Findings feeding back into core (DESIGN.md §9): `events.send` doesn't escape JSON strings; incoming event data caps replies at 256B; richer raw button events (down/up) would unlock hold recognizers; `ctx.generation_id` should be exposed to Lua.

## Test plan
- `cd spikes/arc && lua sim/scenarios.lua` — 46/46
- `./tools/run-tests.py build` — both m5stick-arc envs added to the CI list; built locally (m5stick, m5sticks3)
- Live: deployed worker + flashed M5StickS3; full turn/remix/hydrate cycles verified over the monitor WebSocket

🤖 Generated with [Claude Code](https://claude.com/claude-code)