### PR TITLE
feat(Sandbox): time-slice on_tick so a slow app costs FPS, not responsiveness

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -46,6 +46,7 @@ void loop()  { sandbox.loop(); }
 | `systemButton` | `Resident::SystemButton*` | `nullptr` | Optional button the runtime polls to skip the boot countdown (and, via `onSystemButtonHold`, a runtime hold gesture). Implement `Resident::SystemButton` and pass a pointer here. |
 | `systemMic` | `Resident::SystemMic*` | `nullptr` | Optional microphone the runtime streams via the mic pump (see [SystemMic](#residentsystemmic)). On M5 boards use the shipped `Resident::M5Mic` (`#include <ResidentM5Mic.h>`); otherwise implement `Resident::SystemMic`. Not a `Driver` — the pump owns its `begin()`/`end()`. |
 | `persistentStore` | `Resident::PersistentStore*` | `nullptr` | Override the backing store for persistence. `nullptr` uses NVS on device; inject a fake in tests. |
+| `tickSliceMs` | `uint32_t` | `8` | Wall-clock budget for one continuous slice of `on_tick`. A frame that outruns it yields and resumes on the next `loop()` pass (see [Tick slicing](#tick-slicing)). `0` disables slicing. |
 | `statusDisplay` | `SystemDisplay*` | `nullptr` | **Deprecated** — use `systemDisplay`. Kept as a fallback; a compile-time warning nudges migration. |
 | `statusLED` | `SystemLED*` | `nullptr` | **Deprecated** — use `systemLED`. Kept as a fallback; a compile-time warning nudges migration. |
 
@@ -733,6 +734,45 @@ All callbacks receive a `ctx` table. `on_tick` also receives `dt_ms` (integer, m
 | `localtime_m` | integer | Local minute — equals `utc_m` unless a timezone has been set |
 
 `localtime_h` / `localtime_m` reflect local time only after `Sandbox::setTimezone` succeeds. Otherwise they are equal to `utc_h` / `utc_m`.
+
+Every field above is sampled **once, when the frame starts**, and stays fixed
+for the frame's whole life even if it spans several slices (see
+[Tick slicing](#tick-slicing)). Motion computed against `time_ms` or `dt_ms`
+is therefore stable regardless of how expensive the frame is.
+
+### Tick slicing
+
+`on_tick` runs on a coroutine with a wall-clock budget of
+`SandboxConfig::tickSliceMs` (default 8 ms). A frame that finishes inside its
+budget behaves exactly like a plain call. A frame that outruns it is yielded
+mid-flight: `Sandbox::loop()` returns, the rest of the system runs, and the
+**same frame** resumes on the next pass.
+
+```
+loop() pass 1:  [courier][drivers][overlays]  frame slice ─┐
+loop() pass 2:  [courier][drivers][overlays]  frame slice ─┤ one on_tick
+loop() pass 3:  [courier][drivers][overlays]  frame slice ─┘
+loop() pass 4:  [courier][drivers][overlays]  FRAME READY → next frame
+```
+
+An expensive app therefore costs frame rate, not system responsiveness —
+networking, driver polling and overlay drawing keep running at full loop rate
+throughout. The app is told the truth about the cost: `dt_ms` spans
+frame-start to frame-start, so a frame that takes a second reports ~1000 ms
+next time round, and time-based motion stays correct at the lower rate.
+
+Guarantees while a frame is in flight:
+
+- No second frame starts — frames never overlap.
+- `on_event` does not run. A queued event dispatches once the frame completes,
+  so a handler never observes half-updated app state.
+- `loadApp`, `loadShader` and `suspendApp` abandon the frame cleanly.
+
+Set `tickSliceMs = 0` to opt out and run each frame as one uninterrupted call.
+
+**Limitation:** a frame running below a C-call boundary — an extension binding
+that called back into Lua — has no resumable continuation and cannot be
+yielded. Such a frame runs to completion in the current pass.
 
 ### `event` table
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## Unreleased
+
+### Time-sliced `on_tick`
+
+`on_tick` now runs on a reusable coroutine with a wall-clock slice budget
+(`SandboxConfig::tickSliceMs`, default **8 ms**). A frame that outruns its
+slice yields mid-flight; `Sandbox::loop()` returns so Courier, driver
+`update()`, overlays and the system button all get their turn, and the *same*
+frame resumes on the next pass until it completes.
+
+Previously an expensive frame held the main loop for its entire duration —
+network servicing, driver polling and overlay drawing all stopped until it
+returned, and a frame that never returned wedged the device with no way back
+in (an OTA could not land, because OTA is driven from the loop the app was
+holding). Now an expensive app degrades to a lower frame rate instead.
+
+- **`ctx` is built once per frame**, never on resume. `time_ms`,
+  `trigger_count` and the time-of-day fields are frozen for the frame's whole
+  life, so motion computed against them stays correct no matter how many
+  slices the frame takes. `dt_ms` spans frame-start to frame-start, so a frame
+  costing a second reports ~1000 ms next time round — an honest 1 FPS.
+- **Frames never overlap.** No new frame starts while one is in flight, even
+  if `TICK_INTERVAL` has elapsed.
+- **`on_event` no longer interleaves with a suspended `on_tick`.** Events
+  queued mid-frame dispatch once the frame completes, so an event handler
+  cannot observe the app's half-updated state.
+- `loadApp` / `loadShader` / `suspendApp` abandon an in-flight frame cleanly.
+  This matters more than it used to: `Courier::loop()` runs *between* slices,
+  so an app-load message can now arrive while a frame is parked.
+- **`tickSliceMs = 0` restores the old un-sliced behaviour** — one
+  uninterrupted call per frame.
+
+A frame that finishes inside its slice is untouched: same single call, same
+timing, no yield. The only cost is a count hook every 250 VM instructions.
+
+Not covered: slicing cannot interrupt a frame running below a C-call boundary
+(an extension binding that called back into Lua). Such a frame has no
+resumable continuation and runs to completion in the current pass.
+
 ## v0.7.0
 
 Theme: channel-based message routing — an envelope `channel` field steers messages onto a data plane, a control plane, or a custom slot, replacing the single flat `onMessage`/reserved-type dispatch as the routing new senders should use. Also in this release: `SystemMic` becomes a standalone capture interface with a shipped M5 driver.

--- a/src/ResidentSandbox.cpp
+++ b/src/ResidentSandbox.cpp
@@ -105,6 +105,11 @@ Sandbox::~Sandbox()
     _deferredLoadJson = nullptr;
   }
   if (_lua) {
+    abandonTickFrame();
+    if (_tickCoRef != LUA_NOREF)
+      luaL_unref(_lua, LUA_REGISTRYINDEX, _tickCoRef);
+    _tickCo = nullptr;
+
     if (_initFuncRef != LUA_NOREF)
       luaL_unref(_lua, LUA_REGISTRYINDEX, _initFuncRef);
     if (_onTickFuncRef != LUA_NOREF)
@@ -869,11 +874,25 @@ void Sandbox::loop() {
   // Networked apps tick only once connected (unchanged); standalone always.
   if (_courier.has_value() && !isConnected()) return;
 
+  // A frame parked mid-execution owns the Lua VM for this pass: run one more
+  // slice of it, and start nothing else. No new frame (frames never overlap),
+  // and no event dispatch — on_event must not interleave with a suspended
+  // on_tick, which would let it observe the app's half-updated state. The
+  // queued event waits for the frame to finish.
+  if (_tickInFlight) {
+    resumeTickFrame();
+    return;
+  }
+
   unsigned long now = millis();
   unsigned long elapsed = now - _lastTickTime;
   if (elapsed >= TICK_INTERVAL) {
-    callOnTick(elapsed);
+    // Stamped at frame START, before the frame runs, so the next frame's
+    // dt_ms spans start-to-start and covers everything this frame cost.
+    // A frame that takes a second reports ~1000ms next time round: the app
+    // sees an honest 1 FPS and time-based motion stays correct.
     _lastTickTime = now;
+    callOnTick(elapsed);
   }
 
   processNextEvent();
@@ -1286,6 +1305,10 @@ bool Sandbox::isAppRunning() const
 void Sandbox::suspendApp()
 {
   if (_runState != RunState::Running) return;
+  // Suspension means "the app stops ticking now". A frame parked mid-flight
+  // is dropped rather than held: resuming starts a fresh frame with a current
+  // ctx, instead of finishing one whose clock stopped before the suspension.
+  abandonTickFrame();
   _runState = RunState::Suspended;
   notifyAppRunning(false);  // free the status display for overlay text
 }
@@ -1307,6 +1330,11 @@ bool Sandbox::isAppSuspended() const
 bool Sandbox::compileApp(const char* code)
 {
   if (!_lua) return false;
+
+  // The outgoing app may have a frame parked mid-execution (Courier::loop()
+  // runs between slices, so an app/shader message can land here while one is
+  // in flight). Drop it before its on_tick reference is unref'd underneath it.
+  abandonTickFrame();
 
   // Free old function references
   if (_initFuncRef != LUA_NOREF) {
@@ -1421,7 +1449,7 @@ bool Sandbox::callInit()
   lua_setfield(_lua, -2, "trigger_count");
 
   // Time-of-day fields
-  pushLocalTimeFields();
+  pushLocalTimeFields(_lua);
 
   int result = lua_pcall(_lua, 1, 0, 0);
   if (result != 0) {
@@ -1434,57 +1462,150 @@ bool Sandbox::callInit()
   return true;
 }
 
-void Sandbox::callOnTick(unsigned long dt_ms)
+// Count hook installed on the tick coroutine while a frame runs. Fires every
+// SLICE_HOOK_COUNT VM instructions; yields the frame once it has held the CPU
+// for cfg.tickSliceMs. lua_yield does not return — it unwinds to lua_resume,
+// which reports LUA_YIELD back to resumeTickFrame().
+void Sandbox::sliceHook(lua_State* L, lua_Debug* ar)
 {
-  if (!_lua || _onTickFuncRef == LUA_NOREF) return;
+  (void)ar;
 
-  lua_rawgeti(_lua, LUA_REGISTRYINDEX, _onTickFuncRef);
+  lua_getfield(L, LUA_REGISTRYINDEX, REGISTRY_KEY);
+  Sandbox* self = (Sandbox*)lua_touserdata(L, -1);
+  lua_pop(L, 1);
+  if (!self) return;
 
-  // Push ctx table
+  if (millis() - self->_sliceStartMs < self->_config.tickSliceMs) return;
+
+  // Only a Lua frame can yield. If the app is currently running below a
+  // C-call boundary — an extension binding that called back into Lua — there
+  // is no resumable continuation, so let the frame run on and complete in
+  // this pass rather than erroring it.
+  if (!lua_isyieldable(L)) return;
+
+  lua_yield(L, 0);
+}
+
+// Start a frame: build ctx once and leave (fn, ctx, dt) on the coroutine
+// stack ready for the first resume. Returns false if no coroutine could be
+// created, in which case no frame is in flight.
+bool Sandbox::beginTickFrame(unsigned long dt_ms)
+{
+  if (!_tickCo) {
+    _tickCo = lua_newthread(_lua);
+    if (!_tickCo) return false;
+    // Anchor it in the registry (also pops it off _lua's stack) so the
+    // collector cannot reclaim a coroutine that a frame is parked on.
+    _tickCoRef = luaL_ref(_lua, LUA_REGISTRYINDEX);
+  }
+
+  // Clear anything a previous frame left behind (an error unwind, or an
+  // abandoned frame) so this one starts on an empty stack.
+  lua_closethread(_tickCo, _lua);
+
+  lua_rawgeti(_tickCo, LUA_REGISTRYINDEX, _onTickFuncRef);
+
+  // ctx is built exactly once per frame, here — never on resume. Every slice
+  // of this frame therefore sees the same time_ms, trigger_count and
+  // time-of-day. A clock that moved between slices would silently corrupt any
+  // motion the app derives from it.
   unsigned long t = millis() - _triggerResetTime;
-  lua_newtable(_lua);
-  lua_pushinteger(_lua, t);
-  lua_setfield(_lua, -2, "time_ms");
-  lua_pushinteger(_lua, _triggerCount);
-  lua_setfield(_lua, -2, "trigger_count");
+  lua_newtable(_tickCo);
+  lua_pushinteger(_tickCo, t);
+  lua_setfield(_tickCo, -2, "time_ms");
+  lua_pushinteger(_tickCo, _triggerCount);
+  lua_setfield(_tickCo, -2, "trigger_count");
 
   // Time-of-day fields
-  pushLocalTimeFields();
+  pushLocalTimeFields(_tickCo);
 
-  lua_pushinteger(_lua, dt_ms);
+  lua_pushinteger(_tickCo, dt_ms);
 
-  int result = lua_pcall(_lua, 2, 0, 0);
-  if (result != 0) {
-    const char* errMsg = lua_tostring(_lua, -1);
-    Serial.printf("Resident::Sandbox: on_tick() error: %s\n", errMsg);
+  _tickInFlight = true;
+  _tickResumeArgs = 2;   // (ctx, dt) — consumed by the first resume
+  return true;
+}
 
-    // Rate-limit on_tick errors (fires 10x/sec)
-    unsigned long now = millis();
-    if (_runtimeErrorCount < RUNTIME_ERROR_MAX_BURST ||
-        now - _lastRuntimeErrorMillis >= RUNTIME_ERROR_COOLDOWN) {
-      emitTelemetry("runtime_error", errMsg);
-      _lastRuntimeErrorMillis = now;
-      _runtimeErrorCount++;
-    }
-    lua_pop(_lua, 1);
+// Run one slice of the in-flight frame. Leaves _tickInFlight set if the frame
+// yielded (more slices to come), clears it when the frame finishes or errors.
+void Sandbox::resumeTickFrame()
+{
+  if (!_tickInFlight || !_tickCo) return;
+
+  _sliceStartMs = millis();
+
+  // Re-armed each slice: this is also what makes tickSliceMs == 0 a true
+  // opt-out — with no hook installed the frame can never yield, so the first
+  // resume runs it to completion exactly as a plain call would.
+  const bool sliced = _config.tickSliceMs > 0;
+  lua_sethook(_tickCo, sliced ? &Sandbox::sliceHook : nullptr,
+              sliced ? LUA_MASKCOUNT : 0, sliced ? SLICE_HOOK_COUNT : 0);
+
+  int nres = 0;
+  int status = lua_resume(_tickCo, _lua, _tickResumeArgs, &nres);
+  _tickResumeArgs = 0;
+
+  if (status == LUA_YIELD) return;   // budget spent; frame stays parked
+
+  _tickInFlight = false;
+  lua_sethook(_tickCo, nullptr, 0, 0);
+
+  if (status == LUA_OK) {
+    if (nres > 0) lua_pop(_tickCo, nres);   // on_tick returns nothing; be safe
+    return;
+  }
+
+  const char* errMsg = lua_tostring(_tickCo, -1);
+  Serial.printf("Resident::Sandbox: on_tick() error: %s\n", errMsg);
+
+  // Rate-limit on_tick errors (fires 10x/sec)
+  unsigned long now = millis();
+  if (_runtimeErrorCount < RUNTIME_ERROR_MAX_BURST ||
+      now - _lastRuntimeErrorMillis >= RUNTIME_ERROR_COOLDOWN) {
+    emitTelemetry("runtime_error", errMsg);
+    _lastRuntimeErrorMillis = now;
+    _runtimeErrorCount++;
+  }
+  lua_closethread(_tickCo, _lua);   // discard the error object + unwound stack
+}
+
+// Drop a frame that is parked mid-execution. Safe because the coroutine is
+// suspended, never running, at every call site: the app is being replaced,
+// suspended, or torn down. Courier::loop() runs between slices, so a message
+// that loads a new app can land here while a frame is in flight.
+void Sandbox::abandonTickFrame()
+{
+  if (!_tickInFlight) return;
+  _tickInFlight = false;
+  _tickResumeArgs = 0;
+  if (_tickCo) {
+    lua_sethook(_tickCo, nullptr, 0, 0);
+    lua_closethread(_tickCo, _lua);
   }
 }
 
-void Sandbox::pushLocalTimeFields()
+void Sandbox::callOnTick(unsigned long dt_ms)
+{
+  if (!_lua || _onTickFuncRef == LUA_NOREF) return;
+  if (!beginTickFrame(dt_ms)) return;
+  resumeTickFrame();
+}
+
+void Sandbox::pushLocalTimeFields(lua_State* L)
 {
   int utcH = UTC.hour();
   int utcM = UTC.minute();
-  lua_pushinteger(_lua, utcH);
-  lua_setfield(_lua, -2, "utc_h");
-  lua_pushinteger(_lua, utcM);
-  lua_setfield(_lua, -2, "utc_m");
+  lua_pushinteger(L, utcH);
+  lua_setfield(L, -2, "utc_h");
+  lua_pushinteger(L, utcM);
+  lua_setfield(L, -2, "utc_m");
 
   int localH = _hasTimezone ? _tz.hour()   : utcH;
   int localM = _hasTimezone ? _tz.minute() : utcM;
-  lua_pushinteger(_lua, localH);
-  lua_setfield(_lua, -2, "localtime_h");
-  lua_pushinteger(_lua, localM);
-  lua_setfield(_lua, -2, "localtime_m");
+  lua_pushinteger(L, localH);
+  lua_setfield(L, -2, "localtime_h");
+  lua_pushinteger(L, localM);
+  lua_setfield(L, -2, "localtime_m");
 }
 
 void Sandbox::processNextEvent()

--- a/src/ResidentSandbox.h
+++ b/src/ResidentSandbox.h
@@ -445,6 +445,27 @@ private:
     unsigned long _lastTickTime = 0;
     static constexpr unsigned long TICK_INTERVAL = 100; // 10 FPS
 
+    // Time-sliced tick execution. on_tick runs on a reusable coroutine so a
+    // frame that outruns cfg.tickSliceMs can yield mid-flight and resume on a
+    // later loop() pass, leaving the main loop free to service Courier,
+    // driver update(), overlays and the system button in between. The
+    // coroutine is anchored in the registry (_tickCoRef) so the collector
+    // cannot take it while a frame is parked on it.
+    struct lua_State* _tickCo = nullptr;
+    int _tickCoRef = -2;            // LUA_NOREF; lauxlib.h is not includable here
+    bool _tickInFlight = false;     // a frame is parked mid-execution
+    int _tickResumeArgs = 0;        // 2 (ctx, dt) on a frame's first resume, else 0
+    unsigned long _sliceStartMs = 0;
+    // VM instructions between budget checks. Sets the granularity floor: a
+    // slice can overrun the budget by up to this many instructions' worth of
+    // work. Small enough that on-device slices track the budget closely,
+    // large enough that the hook is not a measurable tax on normal frames.
+    static constexpr int SLICE_HOOK_COUNT = 250;
+    bool beginTickFrame(unsigned long dt_ms);  // build ctx, arm the coroutine
+    void resumeTickFrame();                     // run one slice
+    void abandonTickFrame();                    // drop a parked frame
+    static void sliceHook(struct lua_State* L, struct lua_Debug* ar);
+
     // Event queue
     struct Event {
         enum Type { BUTTON, APP_EVENT, DRIVER } type;
@@ -475,7 +496,10 @@ private:
     bool callInit();  // true if init ran without error (or no init function)
     void callOnTick(unsigned long dt_ms);
     void processNextEvent();
-    void pushLocalTimeFields();  // pushes utc_h/utc_m/localtime_h/localtime_m onto the Lua table at stack top
+    // Pushes utc_h/utc_m/localtime_h/localtime_m onto the table at the top of
+    // L's stack. Takes the state explicitly because a tick frame builds its
+    // ctx on the tick coroutine, not on the main state.
+    void pushLocalTimeFields(struct lua_State* L);
     void pushAppEvent(const char* name, const char* dataJson, const char* from, uint32_t ts_ms);
     void notifyAppRunning(bool running);
     static void driverEventHandler(void* ctx, const char* name,

--- a/src/ResidentSandboxConfig.h
+++ b/src/ResidentSandboxConfig.h
@@ -74,6 +74,25 @@ struct SandboxConfig {
   bool persistApps = true;
   PersistentStore* persistentStore = nullptr;
 
+  // Wall-clock budget for one continuous slice of on_tick, in milliseconds.
+  // A frame that outruns it is yielded mid-flight: Sandbox::loop() returns so
+  // the rest of the system (Courier, driver update(), overlays, the system
+  // button) gets its turn, and the SAME frame resumes on the next pass. An
+  // expensive app therefore degrades to a lower frame rate instead of holding
+  // the main loop for the whole frame.
+  //
+  // A frame that finishes inside its slice is untouched — same single call,
+  // same timing as before. ctx is built once per frame, so time_ms and the
+  // time-of-day fields do not move between slices and motion computed from
+  // them stays correct.
+  //
+  // 0 disables slicing: on_tick runs as one uninterrupted call.
+  //
+  // Slicing cannot interrupt a frame that is below a C-call boundary (an
+  // extension binding that called back into Lua); such a frame runs to
+  // completion in the current pass.
+  uint32_t tickSliceMs = 8;
+
   // Networking opt-in. Presence ⇒ Sandbox constructs a Courier::Client with
   // this config, drives WiFi/transports, fires onConnected/onMessage/etc.
   // Absence ⇒ standalone runtime, no WiFi pulled in.

--- a/test/unit/test/test_tick_slicing/test_tick_slicing.cpp
+++ b/test/unit/test/test_tick_slicing/test_tick_slicing.cpp
@@ -1,0 +1,288 @@
+// Behavioral tests for time-sliced on_tick execution.
+//
+// Contract under test: an app frame that outruns its slice budget must not
+// hold the main loop. The frame yields, Sandbox::loop() returns so the rest
+// of the system (Courier, driver update(), overlays, buttons) gets its turn,
+// and the frame resumes on the next pass until it completes. A slow app
+// degrades to a lower frame rate instead of stalling the device.
+//
+// Observability: a `probe` driver counts update() calls (the loop work that
+// must keep running between slices) and exposes probe.burn(ms), which
+// advances the fake clock from inside Lua — that is how a test app spends
+// wall time mid-frame without real work. Frame progress is read back out of
+// the Lua VM via Sandbox's *ForTest global accessors.
+#include <unity.h>
+
+#include "ResidentSandbox.cpp"
+
+namespace {
+
+class SliceProbe : public Resident::Driver {
+public:
+  int updateCount = 0;
+
+  const char* name() const override { return "probe"; }
+  void update() override { updateCount++; }
+
+  void registerModule(Resident::LuaModule& m) override {
+    m.method<SliceProbe, &SliceProbe::luaBurn>("burn");
+  }
+
+  // probe.burn(ms) — spend `ms` of wall time. Advancing the stub clock is the
+  // native stand-in for expensive work: the slice hook reads millis(), so this
+  // drives the budget exactly as real compute would on device.
+  int luaBurn(lua_State* L) {
+    testMillis() += (unsigned long)luaL_checkinteger(L, 1);
+    return 0;
+  }
+};
+
+SliceProbe* probe = nullptr;
+Resident::Sandbox* sandbox = nullptr;
+
+// ~400 ms of work per frame, spent in small increments so the count hook has
+// plenty of instruction boundaries to fire on. Records ctx.time_ms at both
+// ends of the frame so the freeze contract can be checked.
+constexpr const char* SLOW_APP =
+    "frames = 0\n"
+    "done = false\n"
+    "events = 0\n"
+    "t_first = -1\n"
+    "t_last = -1\n"
+    "last_dt = -1\n"
+    "function on_tick(ctx, dt)\n"
+    "  frames = frames + 1\n"
+    "  done = false\n"
+    "  t_first = ctx.time_ms\n"
+    "  last_dt = dt\n"
+    "  for i = 1, 400 do probe.burn(1) end\n"
+    "  t_last = ctx.time_ms\n"
+    "  done = true\n"
+    "end\n"
+    "function on_event(ctx, e) events = events + 1 end\n";
+
+// A frame that finishes well inside any sane slice budget.
+constexpr const char* FAST_APP =
+    "frames = 0\n"
+    "done = false\n"
+    "function on_tick(ctx, dt)\n"
+    "  frames = frames + 1\n"
+    "  done = true\n"
+    "end\n";
+
+void makeSandbox(uint32_t sliceMs) {
+  probe = new SliceProbe();
+  Resident::SandboxConfig cfg;
+  cfg.deviceType  = "native-test";
+  cfg.extensions  = {probe};
+  cfg.persistApps = false;
+  cfg.tickSliceMs = sliceMs;
+  sandbox = new Resident::Sandbox(cfg);
+  sandbox->setup();
+}
+
+// One loop() pass with no externally-injected time. Any clock movement comes
+// from the app itself (probe.burn), so slicing is measured against the app's
+// own cost rather than a synthetic jump.
+void pass(int times = 1) {
+  for (int i = 0; i < times; i++) sandbox->loop();
+}
+
+// Advance past TICK_INTERVAL so the next pass starts a frame.
+void armTick() { testMillis() += 200; }
+
+// Run passes until the in-flight frame reports done, bounded so a broken
+// implementation fails the assert instead of hanging the suite.
+int passesUntilFrameDone(int limit = 500) {
+  int n = 0;
+  while (n < limit && !sandbox->luaGlobalBoolForTest("done")) {
+    sandbox->loop();
+    n++;
+  }
+  return n;
+}
+
+}  // namespace
+
+void setUp(void) {
+  testMillis() = 0;
+  probe = nullptr;
+  sandbox = nullptr;
+}
+
+void tearDown(void) {
+  delete sandbox; sandbox = nullptr;
+  delete probe;   probe = nullptr;
+}
+
+// A frame inside its budget must behave exactly as before slicing existed:
+// entered and completed within a single loop() pass.
+void test_fast_frame_completes_in_one_pass(void) {
+  makeSandbox(8);
+  sandbox->loadApp(FAST_APP);
+
+  armTick();
+  pass();
+
+  TEST_ASSERT_TRUE(sandbox->luaGlobalBoolForTest("done"));
+  TEST_ASSERT_EQUAL_INT(1, sandbox->luaGlobalIntForTest("frames"));
+}
+
+// The headline contract: a frame that outruns the slice spans multiple loop()
+// passes, and driver update() runs between the slices.
+void test_slow_frame_yields_and_loop_work_runs_between_slices(void) {
+  makeSandbox(8);
+  sandbox->loadApp(SLOW_APP);
+
+  armTick();
+  pass();
+
+  // Frame started but did not finish in the first pass.
+  TEST_ASSERT_EQUAL_INT(1, sandbox->luaGlobalIntForTest("frames"));
+  TEST_ASSERT_FALSE(sandbox->luaGlobalBoolForTest("done"));
+
+  int updatesAtYield = probe->updateCount;
+  int passes = passesUntilFrameDone();
+
+  TEST_ASSERT_TRUE(sandbox->luaGlobalBoolForTest("done"));
+  TEST_ASSERT_GREATER_THAN_INT(0, passes);          // took more than the first pass
+  TEST_ASSERT_GREATER_THAN_INT(updatesAtYield, probe->updateCount);  // loop kept working
+}
+
+// ctx is built once at frame start. A frame spanning many slices must see the
+// same time_ms at its end as at its start — a moving goalpost would corrupt
+// any motion computed against it.
+void test_ctx_time_is_frozen_across_slices(void) {
+  makeSandbox(8);
+  sandbox->loadApp(SLOW_APP);
+
+  armTick();
+  pass();
+  passesUntilFrameDone();
+
+  int first = sandbox->luaGlobalIntForTest("t_first");
+  int last  = sandbox->luaGlobalIntForTest("t_last");
+  TEST_ASSERT_GREATER_OR_EQUAL_INT(0, first);
+  TEST_ASSERT_EQUAL_INT(first, last);
+}
+
+// No frame overlap: while one frame is in flight, elapsed time past
+// TICK_INTERVAL must not start another.
+void test_no_new_frame_starts_while_one_is_in_flight(void) {
+  makeSandbox(8);
+  sandbox->loadApp(SLOW_APP);
+
+  armTick();
+  pass();
+  TEST_ASSERT_FALSE(sandbox->luaGlobalBoolForTest("done"));
+
+  // The app's own burn() has already pushed the clock well past TICK_INTERVAL.
+  // Keep passing; on_tick must still have been entered exactly once.
+  pass(3);
+  TEST_ASSERT_EQUAL_INT(1, sandbox->luaGlobalIntForTest("frames"));
+}
+
+// The app is told the truth about how long its frame took: the next frame's
+// dt_ms covers the whole of the previous frame, so time-based motion stays
+// correct at a degraded frame rate.
+void test_next_frame_dt_covers_full_previous_frame(void) {
+  makeSandbox(8);
+  sandbox->loadApp(SLOW_APP);
+
+  armTick();
+  pass();
+  passesUntilFrameDone();
+  TEST_ASSERT_EQUAL_INT(1, sandbox->luaGlobalIntForTest("frames"));
+
+  // Second frame: dt must account for the ~400ms the first frame spent.
+  armTick();
+  pass();
+  TEST_ASSERT_EQUAL_INT(2, sandbox->luaGlobalIntForTest("frames"));
+  TEST_ASSERT_GREATER_OR_EQUAL_INT(400, sandbox->luaGlobalIntForTest("last_dt"));
+}
+
+// on_event must never interleave with a suspended on_tick — an event arriving
+// mid-frame waits for the frame to complete.
+void test_events_do_not_dispatch_mid_frame(void) {
+  makeSandbox(8);
+  sandbox->loadApp(SLOW_APP);
+
+  armTick();
+  pass();
+  TEST_ASSERT_FALSE(sandbox->luaGlobalBoolForTest("done"));
+
+  sandbox->sendAppEvent("ping", "{}");
+  pass(2);
+  TEST_ASSERT_EQUAL_INT(0, sandbox->luaGlobalIntForTest("events"));  // still mid-frame
+
+  passesUntilFrameDone();
+  pass(2);   // frame complete; the queued event may now dispatch
+  TEST_ASSERT_EQUAL_INT(1, sandbox->luaGlobalIntForTest("events"));
+}
+
+// Opt-out: tickSliceMs == 0 restores the un-sliced path — the whole frame
+// runs to completion inside one loop() pass.
+void test_slicing_disabled_runs_frame_in_one_pass(void) {
+  makeSandbox(0);
+  sandbox->loadApp(SLOW_APP);
+
+  armTick();
+  pass();
+
+  TEST_ASSERT_TRUE(sandbox->luaGlobalBoolForTest("done"));
+  TEST_ASSERT_EQUAL_INT(1, sandbox->luaGlobalIntForTest("frames"));
+}
+
+// Loading a new app while a frame is mid-flight must abandon it cleanly and
+// leave the new app running.
+void test_load_app_abandons_in_flight_frame(void) {
+  makeSandbox(8);
+  sandbox->loadApp(SLOW_APP);
+
+  armTick();
+  pass();
+  TEST_ASSERT_FALSE(sandbox->luaGlobalBoolForTest("done"));
+
+  sandbox->loadApp(FAST_APP);
+  TEST_ASSERT_TRUE(sandbox->isAppRunning());
+
+  armTick();
+  pass();
+  TEST_ASSERT_TRUE(sandbox->luaGlobalBoolForTest("done"));
+  TEST_ASSERT_EQUAL_INT(1, sandbox->luaGlobalIntForTest("frames"));
+}
+
+// Suspending mid-frame abandons the in-flight frame; resuming starts a fresh
+// one rather than continuing a stale coroutine.
+void test_suspend_abandons_in_flight_frame(void) {
+  makeSandbox(8);
+  sandbox->loadApp(SLOW_APP);
+
+  armTick();
+  pass();
+  TEST_ASSERT_FALSE(sandbox->luaGlobalBoolForTest("done"));
+
+  sandbox->suspendApp();
+  pass(3);
+  TEST_ASSERT_EQUAL_INT(1, sandbox->luaGlobalIntForTest("frames"));  // no progress
+
+  sandbox->resumeApp();
+  armTick();
+  pass();
+  TEST_ASSERT_EQUAL_INT(2, sandbox->luaGlobalIntForTest("frames"));  // fresh frame
+}
+
+int main(int, char**) {
+  UNITY_BEGIN();
+  RUN_TEST(test_fast_frame_completes_in_one_pass);
+  RUN_TEST(test_slow_frame_yields_and_loop_work_runs_between_slices);
+  RUN_TEST(test_ctx_time_is_frozen_across_slices);
+  RUN_TEST(test_no_new_frame_starts_while_one_is_in_flight);
+  RUN_TEST(test_next_frame_dt_covers_full_previous_frame);
+  RUN_TEST(test_events_do_not_dispatch_mid_frame);
+  RUN_TEST(test_slicing_disabled_runs_frame_in_one_pass);
+  RUN_TEST(test_load_app_abandons_in_flight_frame);
+  RUN_TEST(test_suspend_abandons_in_flight_frame);
+  UNITY_END();
+  return 0;
+}


### PR DESCRIPTION
## Summary

`on_tick` now runs on a reusable coroutine with a wall-clock slice budget (`SandboxConfig::tickSliceMs`, default **8 ms**). A frame that outruns its slice yields mid-flight; `Sandbox::loop()` returns so Courier, driver `update()`, overlays and the system button all get their turn, and the *same* frame resumes on the next pass until it completes.

Before this, an expensive frame held the main loop for its whole duration — and a frame that never returned wedged the device with no way back in, since OTA is driven from the loop the app was holding. The fix is **degradation, not termination**: a heavy app drops to a lower frame rate and everything else keeps running at full loop rate.

```
loop() pass 1:  [courier][drivers][overlays]  frame slice ─┐
loop() pass 2:  [courier][drivers][overlays]  frame slice ─┤ one on_tick
loop() pass 3:  [courier][drivers][overlays]  frame slice ─┘
loop() pass 4:  [courier][drivers][overlays]  FRAME READY → next frame
```

Contract:

- **`ctx` is built once per frame**, never on resume — `time_ms`, `trigger_count` and the time-of-day fields are frozen for the frame's whole life, so motion computed against them stays correct however many slices it takes.
- **`dt_ms` spans frame-start to frame-start** — a frame costing a second reports ~1000 ms next time round. An honest 1 FPS the app can render against.
- **Frames never overlap** — no new frame starts while one is in flight.
- **`on_event` does not interleave** with a suspended `on_tick`; queued events dispatch after the frame completes, so a handler never sees half-updated state.
- **`loadApp` / `loadShader` / `suspendApp` abandon an in-flight frame cleanly** — newly load-bearing, because `Courier::loop()` now runs *between* slices, so an app-load message can arrive while a frame is parked.
- **`tickSliceMs = 0` opts out** — no hook installed, first resume runs the frame to completion exactly as the old plain call did.

A frame that finishes inside its slice is untouched: same single call, same timing, no yield. The only cost is a count hook every 250 VM instructions.

**Not covered:** slicing cannot interrupt a frame below a C-call boundary (an extension binding that called back into Lua) — no resumable continuation, so it runs to completion in the current pass. Documented in `docs/api.md` and the changelog.

## Test plan

- [x] `./tools/run-tests.py unit` — **125/125 pass**, including the new `test_tick_slicing` suite (9 cases: fast frame unchanged, slow frame yields with driver `update()` running between slices, frozen `ctx`, no overlap, honest `dt_ms`, no mid-frame events, `tickSliceMs=0` opt-out, `loadApp` and `suspendApp` abandoning a parked frame). The suite drives the budget from a probe driver that burns wall time *inside* Lua, so it measures the app's own cost rather than a synthetic clock jump.
- [x] `./tools/run-tests.py static-analysis` — cppcheck clean
- [x] Downstream consumer project builds against this branch and flashes clean
- [x] On hardware (ESP32-S3, M5StickS3): a deliberately over-budget Lua app — a pure-Lua busy loop with a ladder of workload sizes, reporting its own wall-clock FPS from `dt_ms` — was loaded over the wire and exercised interactively. Reported good by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)