### PR TITLE
feat(lua): a `surfaces` module — the render-target registry, readable

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -998,6 +998,28 @@ function on_tick(ctx, dt_ms)
 end
 ```
 
+### `surfaces` module
+
+The board's render targets ([`RenderTargets`](#residentrendertargets)), readable from Lua. Always present: a board that registers no panel lists nothing, which saves every consumer a capability check.
+
+| Function | Returns | Description |
+|----------|---------|-------------|
+| `surfaces.list()` | array | Every registered surface, in registration order |
+| `surfaces.get(name)` | table or nil | One surface by name; `nil` when the board has no such surface |
+
+Each entry is `{ name, w, h, shape }`, with `shape` `"rect"` or `"round"`. The names are the ones `lgfx.bind(name)` and `lvgl.bind(name)` take.
+
+Geometry is read from the panel at call time, not from the registry's cache. A board that calls `addPanel` before its display driver's `begin()` registers zeros — the panel does not know its own size yet — and this read gives the hardware's answer regardless.
+
+Why it exists: a consumer that needs to know what surfaces a board has can ASK the device. A framework module that would otherwise be handed the geometry out of band (a per-board configuration file, a profile layer) can read it instead, and what is read from the hardware cannot disagree with the hardware.
+
+```lua
+local m = surfaces.get("main")
+if m and m.shape == "round" then
+    -- compose in rings; the corners are not glass
+end
+```
+
 ### Shader-compatible globals
 
 These functions are always in scope — they are designed for use in shader expressions as well as full apps.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,6 +32,7 @@ framework hosting, and library-agnostic render targets.
 - **`loadChunk(code)`** / `{channel:"system", type:"chunk"}` runs a chunk in the running app's `lua_State` — globals, timers and events survive, `init()` is not re-called, and a failing chunk leaves the app running.
 - **Render targets**: `Resident::RenderTargets` + `PanelTarget` (geometry plus a synchronous big-endian RGB565 `blit`) is the one place a board declares its panels; the graphics modules build their own machinery over it.
 - **Bind is the claim**: `lgfx.bind` / `lvgl.bind` take ownership of a target (last bind wins), the non-owner's present path stands down silently, and `onAppReset` releases every claim.
+- **Lua `surfaces` module**: `surfaces.list()` / `surfaces.get(name)` read the render-target registry back — `{name, w, h, shape}` per panel, geometry from the `PanelTarget` at call time — so a consumer can ask a device what surfaces it has instead of being told out of band.
 - **Lua `lgfx` module** (`ResidentLgfxModule.h`, opt-in): idiomatic LovyanGFX drawing — rect/roundRect/circle/triangle/line/pixel, text, `flip()` — with `LgfxSpriteTarget<T>` owning the frame buffer.
 - **Lua `lvgl` module** (`ResidentLvglModule.h`, opt-in): retained-mode UI over LVGL 9 + luavgl; the module owns `lv_init`, the tick, the display, its buffers, the flush and the timer pump.
 - **Capture brackets**: `startCapture(stream, format)` / `endCapture()` wrap the mic stream in `{channel:"system", type:"capture"}` frames while the media payloads stay raw.

--- a/prompts/sandbox.md
+++ b/prompts/sandbox.md
@@ -117,6 +117,22 @@ NTP wall clock. UTC unless the device has a timezone.
 `time.is_valid()` · `time.has_timezone()` · `time.hour()` · `time.minute()`
 · `time.second()` · `time.day_id()` (days since boot — a daily cache key).
 
+## surfaces module
+
+The board's drawable surfaces. Geometry comes from the panel itself, so it is
+never stale.
+
+```lua
+for _, s in ipairs(surfaces.list()) do
+  log.info(s.name .. " " .. s.w .. "x" .. s.h .. " " .. s.shape)
+end
+local m = surfaces.get("main")   -- nil when the board has no such surface
+```
+
+Each entry is `{ name, w, h, shape }`; `shape` is `"rect"` or `"round"`. A
+board with no screen lists nothing. These are the same names `lgfx.bind(name)`
+and `lvgl.bind(name)` take.
+
 ## Always-global functions
 
 `rgb(r,g,b)` (normalized floats → packed color, negative-int sentinel) ·

--- a/src/ResidentRenderTargets.h
+++ b/src/ResidentRenderTargets.h
@@ -118,6 +118,19 @@ public:
     return true;
   }
 
+  // Live geometry for an entry. A board that registers its panel before the
+  // driver's begin() caches zeros (the panel does not know its size yet), so
+  // prefer the panel's own numbers whenever it has one — the hardware is the
+  // authority, and a reader should never see a stale zero.
+  static void size(const Entry& e, int32_t& w, int32_t& h) {
+    w = e.w;
+    h = e.h;
+    if (!e.panel) return;
+    const int32_t pw = e.panel->width();
+    const int32_t ph = e.panel->height();
+    if (pw > 0 && ph > 0) { w = pw; h = ph; }
+  }
+
   static int count() { return countRef(); }
 
   // Valid for 0 <= i < count().

--- a/src/ResidentSandbox.cpp
+++ b/src/ResidentSandbox.cpp
@@ -407,6 +407,16 @@ void Sandbox::setupLuaEnvironment()
   lua_pushcfunction(_lua, lua_time_has_timezone);
   lua_setfield(_lua, -2, "has_timezone");
   lua_setglobal(_lua, "time");
+
+  // surfaces module: the board's render targets, readable. Always present —
+  // a board with no drawable surface lists none, which is the honest answer
+  // and saves every consumer a capability check.
+  lua_newtable(_lua);
+  lua_pushcfunction(_lua, lua_surfaces_list);
+  lua_setfield(_lua, -2, "list");
+  lua_pushcfunction(_lua, lua_surfaces_get);
+  lua_setfield(_lua, -2, "get");
+  lua_setglobal(_lua, "surfaces");
 }
 
 void Sandbox::setup()
@@ -2845,6 +2855,53 @@ int Sandbox::lua_log_error(lua_State* L)
     self->emitTelemetry("log_error", msg);
   }
   return 0;
+}
+
+// ── surfaces module ───────────────────────────────────────────────────────
+// The board's render targets, readable from Lua. The registry is where a
+// board declares its drawable surfaces (RenderTargets::addPanel), and this is
+// the read: a consumer that needs to know what surfaces exist and how big
+// they are can ASK instead of being told out of band. Geometry comes from the
+// panel itself, so it cannot go stale.
+static void pushSurface(lua_State* L, const RenderTargets::Entry& e)
+{
+  int32_t w = 0, h = 0;
+  RenderTargets::size(e, w, h);
+  lua_newtable(L);
+  lua_pushstring(L, e.name ? e.name : "");
+  lua_setfield(L, -2, "name");
+  lua_pushinteger(L, w);
+  lua_setfield(L, -2, "w");
+  lua_pushinteger(L, h);
+  lua_setfield(L, -2, "h");
+  lua_pushstring(L, e.shape ? e.shape : "rect");
+  lua_setfield(L, -2, "shape");
+}
+
+// surfaces.list() -> { {name=, w=, h=, shape=}, ... } in registration order.
+int Sandbox::lua_surfaces_list(lua_State* L)
+{
+  const int n = RenderTargets::count();
+  lua_createtable(L, n, 0);
+  for (int i = 0; i < n; i++) {
+    pushSurface(L, RenderTargets::entry(i));
+    lua_rawseti(L, -2, i + 1);
+  }
+  return 1;
+}
+
+// surfaces.get(name) -> the same table, or nil when the board has no such
+// surface. Absence is the honest answer: a screenless board lists nothing.
+int Sandbox::lua_surfaces_get(lua_State* L)
+{
+  const char* name = luaL_checkstring(L, 1);
+  const int i = RenderTargets::indexOf(name);
+  if (i < 0) {
+    lua_pushnil(L);
+    return 1;
+  }
+  pushSurface(L, RenderTargets::entry(i));
+  return 1;
 }
 
 int Sandbox::lua_time_is_valid(lua_State* L)

--- a/src/ResidentSandbox.h
+++ b/src/ResidentSandbox.h
@@ -690,6 +690,8 @@ private:
     static int lua_time_second(lua_State* L);
     static int lua_time_day_id(lua_State* L);
     static int lua_time_has_timezone(lua_State* L);
+    static int lua_surfaces_list(lua_State* L);
+    static int lua_surfaces_get(lua_State* L);
 
     // Math wrapper functions
     static int lua_math_floor(lua_State* L);

--- a/test/unit/test/test_surfaces_module/test_surfaces_module.cpp
+++ b/test/unit/test/test_surfaces_module/test_surfaces_module.cpp
@@ -1,0 +1,123 @@
+// surfaces module: the board's render targets, readable from Lua.
+//
+// The registry is where a board declares its drawable surfaces; this is the
+// read. A consumer that needs to know what surfaces exist and how big they
+// are can ASK the device instead of being told out of band — which is the
+// whole point, because anything told out of band can be wrong.
+#include <unity.h>
+
+#include "ResidentSandbox.cpp"
+#include "ResidentRenderTargets.h"
+
+namespace {
+
+using Resident::RenderTargets;
+
+// A panel whose size is settable, so the "geometry comes from the hardware"
+// property can be tested rather than assumed.
+class FakePanel : public Resident::PanelTarget {
+public:
+  FakePanel(int32_t w, int32_t h) : _w(w), _h(h) {}
+  int32_t width() const override { return _w; }
+  int32_t height() const override { return _h; }
+  void blit(int32_t, int32_t, int32_t, int32_t, const uint16_t*) override {}
+  void resize(int32_t w, int32_t h) { _w = w; _h = h; }
+
+private:
+  int32_t _w, _h;
+};
+
+Resident::Sandbox* sandbox = nullptr;
+FakePanel* main_ = nullptr;
+FakePanel* aux = nullptr;
+
+constexpr const char* IDLE_APP = "function on_tick(ctx, dt) end\n";
+
+// Panels are registered BEFORE this (they are board-lifetime, declared at
+// firmware setup), so build() must not clear the registry.
+void build() {
+  Resident::SandboxConfig cfg;
+  cfg.deviceType = "native-test";
+  sandbox = new Resident::Sandbox(cfg);
+  sandbox->setup();
+
+  // A chunk needs a running app to run inside.
+  JsonDocument doc;
+  doc["channel"] = "system";
+  doc["type"] = "app";
+  doc["code"] = IDLE_APP;
+  sandbox->injectMessage("test", "app", doc);
+}
+
+}  // namespace
+
+void setUp(void) { testMillis() = 0; RenderTargets::clear(); }
+
+void tearDown(void) {
+  delete sandbox; sandbox = nullptr;
+  delete main_; main_ = nullptr;
+  delete aux; aux = nullptr;
+  RenderTargets::clear();
+}
+
+void test_lists_nothing_on_a_screenless_board(void) {
+  build();
+  TEST_ASSERT_TRUE(sandbox->loadChunk("n = #surfaces.list()\n"));
+  TEST_ASSERT_EQUAL_INT(0, sandbox->luaGlobalIntForTest("n"));
+}
+
+void test_lists_registered_panels_in_order(void) {
+  main_ = new FakePanel(240, 135);
+  aux = new FakePanel(64, 64);
+  RenderTargets::addPanel("main", main_);
+  RenderTargets::addPanel("aux", aux, "round");
+  build();
+  TEST_ASSERT_TRUE(sandbox->loadChunk(
+      "local s = surfaces.list()\n"
+      "n = #s\n"
+      "names_in_order = (s[1].name == 'main') and (s[2].name == 'aux')\n"
+      "w, h = s[1].w, s[1].h\n"
+      "shapes = (s[1].shape == 'rect') and (s[2].shape == 'round')\n"));
+  TEST_ASSERT_EQUAL_INT(2, sandbox->luaGlobalIntForTest("n"));
+  TEST_ASSERT_TRUE(sandbox->luaGlobalBoolForTest("names_in_order"));
+  TEST_ASSERT_EQUAL_INT(240, sandbox->luaGlobalIntForTest("w"));
+  TEST_ASSERT_EQUAL_INT(135, sandbox->luaGlobalIntForTest("h"));
+  TEST_ASSERT_TRUE(sandbox->luaGlobalBoolForTest("shapes"));
+}
+
+void test_get_by_name_and_absence(void) {
+  main_ = new FakePanel(320, 172);
+  RenderTargets::addPanel("main", main_);
+  build();
+  TEST_ASSERT_TRUE(sandbox->loadChunk(
+      "local m = surfaces.get('main')\n"
+      "w, h = m.w, m.h\n"
+      "missing = surfaces.get('nosuch') == nil\n"));
+  TEST_ASSERT_EQUAL_INT(320, sandbox->luaGlobalIntForTest("w"));
+  TEST_ASSERT_EQUAL_INT(172, sandbox->luaGlobalIntForTest("h"));
+  TEST_ASSERT_TRUE(sandbox->luaGlobalBoolForTest("missing"));
+}
+
+// The reason the read exists: a board that registers its panel before the
+// display driver's begin() caches zeros, because the panel does not know its
+// own size yet. Reading must give the hardware's answer, not that cache.
+void test_geometry_is_read_from_the_panel_not_the_cache(void) {
+  main_ = new FakePanel(0, 0);        // pre-begin: the panel knows nothing
+  RenderTargets::addPanel("main", main_);
+  main_->resize(466, 466);            // the driver's begin() brings it up
+  build();
+  TEST_ASSERT_TRUE(sandbox->loadChunk(
+      "local m = surfaces.get('main')\n"
+      "w, h = m.w, m.h\n"));
+  TEST_ASSERT_EQUAL_INT(466, sandbox->luaGlobalIntForTest("w"));
+  TEST_ASSERT_EQUAL_INT(466, sandbox->luaGlobalIntForTest("h"));
+}
+
+int main(int, char**) {
+  UNITY_BEGIN();
+  RUN_TEST(test_lists_nothing_on_a_screenless_board);
+  RUN_TEST(test_lists_registered_panels_in_order);
+  RUN_TEST(test_get_by_name_and_absence);
+  RUN_TEST(test_geometry_is_read_from_the_panel_not_the_cache);
+  return UNITY_END();
+}


### PR DESCRIPTION
## Why

A board declares its drawable surfaces with `RenderTargets::addPanel`. Nothing could read that declaration back from Lua — the registry resolves `bind(name)` and is otherwise C++-internal.

So a consumer that needs to know what surfaces a board has must be told **out of band**: a per-board config file, a framework's own profile layer. That is a second source of truth, and it can disagree with the hardware. It does — the arc framework carries a profile file declaring one board's panel as 328×328 when the panel is 466×466, and nothing catches it.

This is the read that removes the need for one.

## What

- `surfaces.list()` — every registered surface, in registration order.
- `surfaces.get(name)` — one by name, or `nil`.

Each entry is `{name, w, h, shape}`, `shape` being `"rect"` or `"round"` — the same names `lgfx.bind(name)` and `lvgl.bind(name)` take. Always present: a screenless board lists nothing, which saves every consumer a capability check.

**Geometry is read from the `PanelTarget` at call time**, not from the registry's cached numbers. A board that calls `addPanel` before its display driver's `begin()` caches zeros — the panel does not know its own size yet. New `RenderTargets::size(entry, w, h)` prefers the panel's own numbers, so C++ readers get the same guarantee.

## Tests

`test_surfaces_module` (4 cases): the empty board, listing order and shapes, get-by-name and absence, and the pre-`begin()` case that motivates live geometry. 218 native tests pass; cppcheck clean.

Docs: `prompts/sandbox.md` (the authoring sheet, per the editing rule), `docs/api.md`, changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)