### PR TITLE
release: v0.8.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.8.0-dev
+## v0.8.0
 
 Theme: the device speaks first. A device hello announces protocol, limits and
 identity on every connect; telemetry and events ride channelled frames with a

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.8.0-dev"
+version: "0.8.0"
 description: "Sandbox with hardware IO and hot reload for ESP32 devices"
 url: "https://github.com/inanimate-tech/resident"
 

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "resident",
-  "version": "0.8.0-dev",
+  "version": "0.8.0",
   "description": "Sandbox with hardware IO and hot reload for ESP32 devices",
   "keywords": "esp32, sandbox, iot, hot-reload",
   "repository": {


### PR DESCRIPTION
Cuts v0.8.0 from `main` as-is. Three lines, no content changes: the `-dev` suffix comes off both manifests and off the changelog heading, which freezes that section per the changelog's own convention.

- `library.json`: `0.8.0-dev` → `0.8.0`
- `idf_component.yml`: `0.8.0-dev` → `0.8.0`
- `docs/changelog.md`: `## v0.8.0-dev` → `## v0.8.0`

Theme: the device speaks first.

Verification, run in the release worktree after the edit:

```
$ ./tools/publish-preflight.py
Local version: 0.8.0
PlatformIO registry latest: 0.7.0
ESP Component Registry latest: 0.7.0

All pre-flight checks passed.

$ ./tools/run-tests.py unit
================ 220 test cases: 220 succeeded in 00:00:30.033 ================
✓ Unit tests passed
```

After merge, tagging `v0.8.0` fires `.github/workflows/publish.yml`, which publishes to the PlatformIO and ESP Component registries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DEMo5xk9324WM7557KAJZG