### PR TITLE
fix(render): a graphics module cannot flatten a board's round panel

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1008,7 +1008,7 @@ The board's render targets ([`RenderTargets`](#residentrendertargets)), readable
 | `surfaces.list()` | array | Every registered surface, in registration order |
 | `surfaces.get(name)` | table or nil | One surface by name; `nil` when the board has no such surface |
 
-Each entry is `{ name, w, h, shape }`, with `shape` `"rect"` or `"round"`. The names are the ones `lgfx.bind(name)` and `lvgl.bind(name)` take.
+Each entry is `{ name, w, h, shape }`, with `shape` `"rect"` or `"round"`. `shape` comes from the board's `addPanel` and a graphics module cannot override it — only a target with no panel takes its shape from the module that declared it. The names are the ones `lgfx.bind(name)` and `lvgl.bind(name)` take.
 
 Geometry is read from the panel at call time; the registry caches nothing for a panel-backed target. This is deliberate: a board registers its panels in a config function that commonly runs during **static init**, before `M5.begin()` and before any display driver's `begin()`, so asking a panel its size there dereferences hardware that does not exist yet. `addPanel` therefore never asks, and every reader gets live numbers.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Fixed: a graphics module could overwrite a board's panel shape. `LgfxModule::addDisplay` defaults `shape = "rect"`, and its registry declaration applied that unconditionally — so a board that registered a round panel and then declared lgfx on it ended up marked rectangular, and every consumer believed it (an app laying itself out by shape drew off the edge of the glass). `RenderTargets::declare(name, module[, shape])` now applies a module's shape only when no panel is registered for that name — a bare sprite, where the module is the only source. Shape is a physical fact about the glass and the board states it once.
+
+---
+
 ## v0.8.1
 
 Courier 0.7.0 support. No Resident source changes — this is the dependency

--- a/src/ResidentLgfxModule.h
+++ b/src/ResidentLgfxModule.h
@@ -213,6 +213,11 @@ public:
   // MODULE_LGFX bit on the target in the RenderTargets registry; geometry
   // comes from the registered PanelTarget when the board registered one
   // (addPanel), else from the drawing target itself.
+  //
+  // `shape` applies ONLY to a target with no PanelTarget behind it — a bare
+  // sprite, where nothing else can say. When the board registered a panel,
+  // that panel's shape is the truth and this argument is ignored: shape is a
+  // physical fact about the glass, and the board states it once.
   bool addDisplay(const char* displayName, LgfxTarget* target,
                   const char* shape = "rect") {
     if (_count >= MAX_DISPLAYS || !displayName || !target) return false;
@@ -327,7 +332,7 @@ private:
   // hardware that does not exist yet. Readers get live geometry from
   // RenderTargets::size().
   static void declare(const Slot& s) {
-    RenderTargets::declare(s.name, s.shape, RenderTargets::MODULE_LGFX);
+    RenderTargets::declare(s.name, RenderTargets::MODULE_LGFX, s.shape);
   }
 
   // Present one frame — the R19 gate. Not the owner? Drop it silently: the

--- a/src/ResidentLvglModule.h
+++ b/src/ResidentLvglModule.h
@@ -103,7 +103,7 @@ public:
     // The module bit only: addDisplay runs from a board's config function,
     // which commonly runs during static init, and measuring a panel there is
     // a crash. Geometry is read when the display is created, on first bind.
-    RenderTargets::declare(displayName, nullptr, RenderTargets::MODULE_LVGL);
+    RenderTargets::declare(displayName, RenderTargets::MODULE_LVGL);
     return true;
   }
 

--- a/src/ResidentRenderTargets.h
+++ b/src/ResidentRenderTargets.h
@@ -103,15 +103,25 @@ public:
     return true;
   }
 
-  // A module's declaration: "I can draw on this target." No geometry — a
-  // module declares at firmware-setup time, which is the same static-init
-  // window addPanel lives in, so asking anything its size here is the same
-  // crash. Geometry comes from size() when someone actually reads.
-  static bool declare(const char* name, const char* shape, uint8_t module) {
+  // A module's declaration: "I can draw on this target." Nothing else.
+  //
+  // No geometry, because a module declares at firmware-setup time — the same
+  // static-init window addPanel lives in, where asking anything its size is a
+  // crash. And NO SHAPE: whether a panel is round is the board's fact, stated
+  // once by addPanel. A module that also asserted a shape would overwrite it
+  // with its own default, which is exactly what happened — lgfx's `shape =
+  // "rect"` default silently flattened a board's "round" on the line after it
+  // was declared, and every consumer downstream believed it.
+  // `shape` is accepted but applied ONLY when no board panel is registered
+  // for this name — a bare sprite, where the module is the only thing that
+  // can say. The registry decides, not the caller, because the caller does
+  // not know whether a board got there first.
+  static bool declare(const char* name, uint8_t module,
+                      const char* shape = nullptr) {
     Entry* e = slot(name);
     if (!e) return false;
-    if (shape) e->shape = shape;
     e->modules |= module;
+    if (shape && !e->panel) e->shape = shape;
     return true;
   }
 

--- a/test/unit/test/test_render_targets/test_render_targets.cpp
+++ b/test/unit/test/test_render_targets/test_render_targets.cpp
@@ -77,11 +77,30 @@ void test_module_declare_never_asks_the_panel_its_size(void) {
   FakePanel panel(240, 135);
   RenderTargets::addPanel("main", &panel);
   panel.sizeReads = 0;
-  RenderTargets::declare("main", nullptr, RenderTargets::MODULE_LGFX);
-  RenderTargets::declare("main", nullptr, RenderTargets::MODULE_LVGL);
+  RenderTargets::declare("main", RenderTargets::MODULE_LGFX);
+  RenderTargets::declare("main", RenderTargets::MODULE_LVGL);
   TEST_ASSERT_EQUAL_INT(0, panel.sizeReads);
   TEST_ASSERT_EQUAL_UINT8(RenderTargets::MODULE_LGFX | RenderTargets::MODULE_LVGL,
                           RenderTargets::entry(0).modules);
+}
+
+// The bug this guards, seen on glass: a board declares its panel round, the
+// lgfx module's addDisplay defaults `shape = "rect"`, and the module's
+// declaration overwrote the board on the very next line. Every consumer then
+// believed the round device was rectangular — an app that lays itself out by
+// shape drew its whole look off the edge of the circle.
+void test_a_module_cannot_flatten_a_boards_round_panel(void) {
+  FakePanel panel(466, 466);
+  RenderTargets::addPanel("main", &panel, "round");
+  RenderTargets::declare("main", RenderTargets::MODULE_LGFX, "rect");
+  TEST_ASSERT_EQUAL_STRING("round", RenderTargets::entry(0).shape);
+}
+
+// ...but a target with no panel behind it has no board to ask, so there the
+// module's shape is the only source and must apply.
+void test_a_module_shape_applies_to_a_panelless_target(void) {
+  RenderTargets::declare("sprite", RenderTargets::MODULE_LGFX, "round");
+  TEST_ASSERT_EQUAL_STRING("round", RenderTargets::entry(0).shape);
 }
 
 void test_modules_merge_onto_one_target(void) {
@@ -199,6 +218,8 @@ int main(int, char**) {
   RUN_TEST(test_add_panel_registers_geometry);
   RUN_TEST(test_add_panel_never_asks_the_panel_its_size);
   RUN_TEST(test_module_declare_never_asks_the_panel_its_size);
+  RUN_TEST(test_a_module_cannot_flatten_a_boards_round_panel);
+  RUN_TEST(test_a_module_shape_applies_to_a_panelless_target);
   RUN_TEST(test_modules_merge_onto_one_target);
   RUN_TEST(test_unowned_target_answers_false_for_everyone);
   RUN_TEST(test_bind_claims_and_last_claim_wins);


### PR DESCRIPTION
## Seen on glass

A round device (M5Stack StopWatch, 466×466) drew its whole look in the top-left corner, mostly off the edge. The app lays itself out by asking whether the panel is round — and it was being told `"rect"`.

## Why

`LgfxModule::addDisplay(name, target, shape = "rect")` defaults the shape, and its registry declaration applied that unconditionally. So a board doing the obvious thing:

```cpp
RenderTargets::addPanel("main", &m5Panel, "round");
lgfxModule.addDisplay("main", &lgfxMain);
```

declared its panel round and had it overwritten as rectangular **on the very next line** — and again at `begin()`. Invisible on a rectangular board, because there both answers agree, which is why it survived the native tests and a stick.

## The fix

Shape is a physical fact about the glass, and the board states it once.

`RenderTargets::declare(name, module[, shape])` now applies a module's shape **only when no panel is registered for that name** — a bare sprite, where the module is the only thing that can say. The registry decides rather than the caller, because the caller cannot know whether a board got there first.

`LgfxModule::addDisplay`'s `shape` argument keeps working for the sprite case and is documented as ignored when a panel exists.

## Tests

Two new native cases: a board's round panel survives a module declaring rect, and a panel-less target still takes the module's shape. The pre-existing `test_system_wire` case that covers the sprite override passes unchanged. 223 tests, cppcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)