### PR TITLE
release: v0.8.2 — re-pin Courier to ^0.8.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## Unreleased
+## v0.8.2
 
-- Fixed: a graphics module could overwrite a board's panel shape. `LgfxModule::addDisplay` defaults `shape = "rect"`, and its registry declaration applied that unconditionally — so a board that registered a round panel and then declared lgfx on it ended up marked rectangular, and every consumer believed it (an app laying itself out by shape drew off the edge of the glass). `RenderTargets::declare(name, module[, shape])` now applies a module's shape only when no panel is registered for that name — a bare sprite, where the module is the only source. Shape is a physical fact about the glass and the board states it once.
+- Courier floor moves to `^0.8.0`, no Resident source changes. A caret range on `0.x` excludes the next minor, so this forces consumers to Courier 0.8.0.
+- Fixed: a graphics module could flatten a board's round panel — `RenderTargets::declare` now applies a module's shape only when no panel is registered for that name.
 
 ---
 

--- a/examples/espidf-basic/main/idf_component.yml
+++ b/examples/espidf-basic/main/idf_component.yml
@@ -12,11 +12,11 @@ dependencies:
   espressif/arduino-esp32:
     version: "^3.0.0"
 
-  # Courier 0.7.0+ (MQTT binary publish and topic-scoped binary receive; the
-  # 0.6.0 floor was receive-parallels-send, which resident's channel routing
-  # requires).
+  # Courier 0.8.0+ (structured MQTT error detail; 0.7.0 added MQTT binary
+  # publish and topic-scoped binary receive, and the 0.6.0 floor was
+  # receive-parallels-send, which resident's channel routing requires).
   inanimate/courier:
-    version: "^0.7.0"
+    version: "^0.8.0"
 
   bblanchon/arduinojson:
     version: "^7.0.0"

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.8.1"
+version: "0.8.2"
 description: "Sandbox with hardware IO and hot reload for ESP32 devices"
 url: "https://github.com/inanimate-tech/resident"
 
@@ -16,12 +16,13 @@ dependencies:
   # envelope field) sees one coherent message stream per transport instead of
   # everything funnelled through onMessage.
   #
-  # The floor is ^0.7.0 because a caret range on 0.x excludes the next minor:
-  # while Resident pinned ^0.6.0, a consumer that wanted courier 0.7.0 (MQTT
-  # binary publish, topic-scoped binary receive) could not have both. Resident
-  # calls none of that new surface itself.
+  # The floor tracks Courier's latest minor because a caret range on 0.x
+  # excludes the next one: while Resident pinned ^0.7.0, a consumer that
+  # wanted courier 0.8.0 (structured MQTT error detail via
+  # MqttTransport::onError) could not have both. Resident calls none of that
+  # new surface itself — it uses Client, Config, State and WebSocketTransport.
   inanimate/courier:
-    version: "^0.7.0"
+    version: "^0.8.0"
   bblanchon/arduinojson:
     version: "^7.0.0"
   # Esp32Lua is not on the ESP component registry. Consumers must provide it

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "resident",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Sandbox with hardware IO and hot reload for ESP32 devices",
   "keywords": "esp32, sandbox, iot, hot-reload",
   "repository": {
@@ -17,7 +17,7 @@
   "frameworks": ["arduino", "espidf"],
   "platforms": "espressif32",
   "dependencies": {
-    "inanimate/courier": "^0.7.0",
+    "inanimate/courier": "^0.8.0",
     "bblanchon/ArduinoJson": "^7.4.2",
     "fischer-simon/Esp32Lua": "^5.4.7"
   },


### PR DESCRIPTION
Courier 0.8.0 is out and on both registries. Re-pins Resident's floor and cuts v0.8.2.

## Why the pin has to move

Courier 0.8.0 is purely additive — `MqttTransport::onError(cb)` and `MqttTransport::ErrorInfo` for structured `MQTT_EVENT_ERROR` detail. `git diff v0.7.0 v0.8.0 -- src/` touches only `MqttTransport.{h,cpp}`; no breaking changes. Resident uses only `Courier::Client`, `Config`, `State` and `WebSocketTransport`, so none of that surface is reachable from here.

The bump is still not cosmetic: a caret range on a `0.x` version excludes the next minor, so while Resident pinned `^0.7.0` a consumer could not depend on Resident and Courier 0.8.0 at the same time. **This forces consumers to Courier 0.8.0** — `^0.8.0` no longer admits 0.7.x.

## Changes

- Courier `^0.7.0` → `^0.8.0` in `library.json`, `idf_component.yml`, and `examples/espidf-basic/main/idf_component.yml`. The four PlatformIO examples pull Courier from git `main`, so they need no bump.
- Version → 0.8.2 in both manifests.
- Changelog entries condensed to one line each — enough to tell whether a change is relevant, then go investigate.

## Verification

- `./tools/run-tests.py all` — static analysis, 223/223 unit tests, full PlatformIO example matrix. Exit 0.
- `examples/espidf-basic` under ESP-IDF 5.5.3: builds clean, `dependencies.lock` resolves `inanimate/courier` → 0.8.0 from the ESP registry.
- `./tools/publish-preflight.py` — versions match, no `-dev`, 0.8.2 > 0.8.1 published on both registries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)