### PR TITLE
The built-in WebSocket transport is optional

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,13 @@
   null in that case, `hasWs()` reports it, and the two internal `ws()` callers
   (the WS-path default in `onCourierTransportsWillConnect`, the mic-stream
   fallback in `updateMicStream`) are gated on it.
+- The legacy un-channelled path runs `onMessageFilter` **before** logging its
+  deprecation notice, not after. The filter is the documented interposition
+  point, so a host that consumes a frame there is not taking delivery of a
+  deprecated one — and a wrapper whose default transport does its own routing
+  (Courier's client hook fires alongside a per-transport hook, not instead of
+  it) consumes every such frame as a duplicate. Logging each as deprecated was
+  both noise and a lie.
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v0.8.3-dev
+
+- The built-in WebSocket transport is optional. `Sandbox` cached
+  `courier().transport<WebSocketTransport>("ws")` unconditionally, but Courier
+  auto-registers `"ws"` only when `Config::host` is set **and**
+  `defaultTransport` is unset or `"ws"`. A Sandbox pointed at another default
+  lane — `defaultTransport = "mqtt"` for a device that carries everything over
+  one MQTT connection — therefore asserted at construction, and with `NDEBUG`
+  took a null reference that crashed at the first `ws()` call. `_ws` now stays
+  null in that case, `hasWs()` reports it, and the two internal `ws()` callers
+  (the WS-path default in `onCourierTransportsWillConnect`, the mic-stream
+  fallback in `updateMicStream`) are gated on it.
+
+---
+
 ## v0.8.2
 
 - Courier floor moves to `^0.8.0`, no Resident source changes. A caret range on `0.x` excludes the next minor, so this forces consumers to Courier 0.8.0.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,24 +1,9 @@
 # Changelog
 
-## v0.8.3-dev
+## v0.8.3
 
-- The built-in WebSocket transport is optional. `Sandbox` cached
-  `courier().transport<WebSocketTransport>("ws")` unconditionally, but Courier
-  auto-registers `"ws"` only when `Config::host` is set **and**
-  `defaultTransport` is unset or `"ws"`. A Sandbox pointed at another default
-  lane — `defaultTransport = "mqtt"` for a device that carries everything over
-  one MQTT connection — therefore asserted at construction, and with `NDEBUG`
-  took a null reference that crashed at the first `ws()` call. `_ws` now stays
-  null in that case, `hasWs()` reports it, and the two internal `ws()` callers
-  (the WS-path default in `onCourierTransportsWillConnect`, the mic-stream
-  fallback in `updateMicStream`) are gated on it.
-- The legacy un-channelled path runs `onMessageFilter` **before** logging its
-  deprecation notice, not after. The filter is the documented interposition
-  point, so a host that consumes a frame there is not taking delivery of a
-  deprecated one — and a wrapper whose default transport does its own routing
-  (Courier's client hook fires alongside a per-transport hook, not instead of
-  it) consumes every such frame as a duplicate. Logging each as deprecated was
-  both noise and a lie.
+- Fixed: `Sandbox` asserted (or crashed on a null reference under `NDEBUG`) when Courier registered no built-in `"ws"` transport — it is now cached only when present, and `hasWs()` reports it.
+- Fixed: the legacy un-channelled path logged its `[deprecated]` notice for messages `onMessageFilter` had already consumed — the filter now runs first.
 
 ---
 

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.8.2"
+version: "0.8.3-dev"
 description: "Sandbox with hardware IO and hot reload for ESP32 devices"
 url: "https://github.com/inanimate-tech/resident"
 

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.8.3-dev"
+version: "0.8.3"
 description: "Sandbox with hardware IO and hot reload for ESP32 devices"
 url: "https://github.com/inanimate-tech/resident"
 

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "resident",
-  "version": "0.8.3-dev",
+  "version": "0.8.3",
   "description": "Sandbox with hardware IO and hot reload for ESP32 devices",
   "keywords": "esp32, sandbox, iot, hot-reload",
   "repository": {

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "resident",
-  "version": "0.8.2",
+  "version": "0.8.3-dev",
   "description": "Sandbox with hardware IO and hot reload for ESP32 devices",
   "keywords": "esp32, sandbox, iot, hot-reload",
   "repository": {

--- a/src/ResidentSandbox.cpp
+++ b/src/ResidentSandbox.cpp
@@ -607,8 +607,15 @@ void Sandbox::onCourierMessage(const char* transportName,
     Serial.printf("Resident::Sandbox: un-channelled '%s' dropped (host speaks hello; legacy path closed)\n", type);
     return;
   }
-  Serial.printf("[deprecated] un-channelled '%s' message; sender should stamp channel\n", type);
+  // The filter runs BEFORE the deprecation notice, not after: it is the
+  // documented interposition point, and a host that consumes a message here
+  // is not taking delivery of a deprecated one. A platform wrapper whose
+  // default transport does its own routing (Hawthorn routes MQTT by topic,
+  // and Courier's client hook fires alongside the per-transport one rather
+  // than instead of it) consumes every un-channelled frame as a duplicate —
+  // logging each one as deprecated would be both noise and a lie.
   if (_messageFilter && !_messageFilter(transportName, type, doc)) return;
+  Serial.printf("[deprecated] un-channelled '%s' message; sender should stamp channel\n", type);
   bool isLoad = strcmp(type, "app") == 0 || strcmp(type, "shader") == 0;
   if (isLoad) maybeShowDescription(doc);
   if (_deferLoads && isLoad) {

--- a/src/ResidentSandbox.cpp
+++ b/src/ResidentSandbox.cpp
@@ -77,7 +77,19 @@ Sandbox::Sandbox(const SandboxConfig& config) : Sandbox() {
       net.defaultTransport = "ws";
     }
     _courier.emplace(net);
-    _ws = &_courier->transport<Courier::WebSocketTransport>("ws");
+
+    // Cache the built-in WS transport ONLY when Courier actually registered
+    // it. Courier's constructor auto-registers "ws" on exactly this
+    // condition; asking for a transport it skipped trips
+    // Client::transport<T>'s assert (and, with NDEBUG, hands back a null
+    // reference that crashes at the first ws() call). A Sandbox whose default
+    // lane is another transport — "mqtt" for a Hawthorn room device — has no
+    // WS at all, and _ws stays null so ws() fails loudly rather than late.
+    bool wsRegistered = net.defaultTransport &&
+                        strcmp(net.defaultTransport, "ws") == 0 &&
+                        net.host && net.host[0] != '\0';
+    _ws = wsRegistered ? &_courier->transport<Courier::WebSocketTransport>("ws")
+                       : nullptr;
   }
 }
 
@@ -1921,10 +1933,14 @@ void Sandbox::onCourierConnected() {
 void Sandbox::onCourierTransportsWillConnect() {
   // Resident's default: built-in WS gets /agents/<deviceType>-agent/<deviceId>.
   // User callback runs after and can override (e.g. set /devices/<id>).
-  String wsPath = String("/agents/") + getDeviceType() + "-agent/" + _deviceId;
-  ws().setEndpoint(_config.network->host ? _config.network->host : "localhost",
-                   443, wsPath.c_str());
-  Serial.printf("[resident] WS path: %s\n", wsPath.c_str());
+  // Skipped entirely when there is no WS transport — a Sandbox with another
+  // default lane never registered one, and there is no endpoint to address.
+  if (_ws) {
+    String wsPath = String("/agents/") + getDeviceType() + "-agent/" + _deviceId;
+    ws().setEndpoint(_config.network->host ? _config.network->host : "localhost",
+                     443, wsPath.c_str());
+    Serial.printf("[resident] WS path: %s\n", wsPath.c_str());
+  }
 
   if (_onTransportsWillConnect) _onTransportsWillConnect();
 }
@@ -2539,7 +2555,7 @@ void Sandbox::updateMicStream()
   const uint8_t* bytes = reinterpret_cast<const uint8_t*>(_micBuf);
   size_t len = (size_t)got * sizeof(int16_t);
   if (_micSink) _micSink(bytes, len);
-  else if (_courier.has_value()) ws().sendBinary(bytes, len);
+  else if (_ws) ws().sendBinary(bytes, len);
 }
 
 bool Sandbox::isAppExtension(Extension* e) const

--- a/src/ResidentSandbox.h
+++ b/src/ResidentSandbox.h
@@ -181,12 +181,19 @@ public:
     void setTimezone(const char* ianaZone);
     bool hasTimezone() const { return _hasTimezone; }
 
-    // Network accessors. Both assert if cfg.network was not set.
+    // Network accessors. courier() asserts if cfg.network was not set; ws()
+    // additionally asserts when no WebSocket transport exists — Courier
+    // auto-registers one only when cfg.network->defaultTransport is unset or
+    // "ws", so a Sandbox with another default lane (e.g. "mqtt") has none.
+    // Gate on hasWs() before calling ws() in code that runs on both.
     Courier::Client& courier();
     Courier::WebSocketTransport& ws();
 
     // True iff cfg.network was set at construction time.
     bool hasNetwork() const { return _courier.has_value(); }
+
+    // True iff the built-in WebSocket transport was registered (see ws()).
+    bool hasWs() const { return _ws != nullptr; }
 
     // ── Setup-phase callback (register before setup()) ──
     using ConfigureNetworkCallback = std::function<void(Courier::Client&)>;


### PR DESCRIPTION
Two fixes a consumer needs before it can stop holding a WebSocket it does not use.

### The built-in WebSocket transport is optional

Courier auto-registers `"ws"` only when `Config::host` is set **and**
`defaultTransport` is unset or `"ws"`, and it logs the skip otherwise. `Sandbox`'s
constructor did not mirror that: it cached
`courier().transport<WebSocketTransport>("ws")` unconditionally. So a Sandbox
pointed at another default lane — `defaultTransport = "mqtt"`, for a device
consolidating everything onto one MQTT connection — tripped
`Client::transport<T>`'s assert, and under `NDEBUG` bound a null reference that
crashed at the first `ws()` call instead.

`_ws` now stays null when Courier did not register one, `hasWs()` reports it, and
both internal `ws()` callers are gated on it: the WS-path default in
`onCourierTransportsWillConnect`, and the mic-stream fallback in
`updateMicStream`. `ws()` keeps its assert, so a caller that genuinely needs WS
still fails loudly rather than late.

### The message filter runs before the deprecation notice

The legacy un-channelled path logged `[deprecated] un-channelled ...` and *then*
offered the frame to `onMessageFilter`. But the filter is the documented
interposition point, so a host that consumes a frame there never took delivery of
a deprecated message.

It matters for a platform wrapper whose default transport routes its own traffic.
Courier's client hook fires **alongside** a per-transport hook rather than instead
of it, so a wrapper that routes (say) MQTT by topic sees every inbound frame a
second time on the client lane and consumes it in the filter. Logging each of
those as deprecated was both noise and a lie — and at MQTT message rates, a line
per message.

### Verification

Consumed by `inanimate-tech/hawthorn-firmware` on its voice-over-MQTT branch and
run on hardware (M5Stack StopWatch, ESP32-S3): boots, registers, connects MQTT as
its only persistent transport, and streams a voice session with no WebSocket
present. 481 native tests pass in that repo, including its Sandbox and
message-dispatch suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)