### PR TITLE
feat(lvgl): eight displays — a body may be several panels

### DIFF
--- a/src/ResidentLvglModule.h
+++ b/src/ResidentLvglModule.h
@@ -74,7 +74,11 @@ namespace Resident {
 
 class LvglModule : public Extension {
 public:
-  static constexpr int MAX_DISPLAYS = 4;
+  // Eight: a body may be several panels rather than one screen — the
+  // hawthorn calendar is seven e-paper panels, each its own display. A
+  // slot is a name, the options and a pointer; nothing is allocated until
+  // that display's first bind.
+  static constexpr int MAX_DISPLAYS = 8;
 
   struct DisplayOptions {
     int32_t dpi = 0;           // 0 = leave LVGL's default

--- a/src/ResidentLvglModule.h
+++ b/src/ResidentLvglModule.h
@@ -74,10 +74,9 @@ namespace Resident {
 
 class LvglModule : public Extension {
 public:
-  // Eight: a body may be several panels rather than one screen — the
-  // hawthorn calendar is seven e-paper panels, each its own display. A
-  // slot is a name, the options and a pointer; nothing is allocated until
-  // that display's first bind.
+  // Eight: a device may be several panels rather than one screen, each
+  // registered as its own display. A slot is a name, the options and a
+  // pointer; nothing is allocated until that display's first bind.
   static constexpr int MAX_DISPLAYS = 8;
 
   struct DisplayOptions {


### PR DESCRIPTION
`LvglModule::MAX_DISPLAYS` goes from 4 to 8. A device may be several panels rather than one screen, each registered as its own surface and given its own `lv_display_t` by this module; with the cap at 4, `lvgl.bind` of a fifth display fails. A slot is a name, the options and a pointer — nothing is allocated until a display's first bind, so the four extra slots cost a few dozen bytes of static.

Unit suite: 223/223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)